### PR TITLE
tec: Provide a Docker environment for developers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,72 @@
+.DEFAULT_GOAL := help
+
+USER = $(shell id -u):$(shell id -g)
+
+ENV_NAME ?= development
+
+ifdef DOCKER
+	CLI = ./docker/bin/cli
+	COMPOSER = ./docker/bin/composer
+	PHP = ./docker/bin/php
+
+	DB_TYPE = MariaDB
+	DB_HOST = database
+	DB_NAME = fusionsuite_development
+	DB_USER = fusionsuite
+	DB_PASS = fusionsuite
+	DB_PORT = 3306
+else
+	CLI = ./bin/cli
+	COMPOSER = composer
+	PHP = php
+
+	DB_TYPE ?= MariaDB
+	DB_HOST ?= localhost
+	DB_NAME ?= fusionsuite_development
+	DB_USER ?= fusionsuite
+	DB_PASS ?= fusionsuite
+	DB_PORT ?= 3306
+endif
+
+ACTIONSCRIPTS_DIRS := $(wildcard ActionScripts/*)
+ACTIONSCRIPTS_DIRS := $(filter-out ActionScripts/autoload.php, $(ACTIONSCRIPTS_DIRS))
+
+.PHONY: docker-start
+docker-start: ## Start a development server with Docker
+	@echo "Running webserver on http://localhost:8000"
+	docker-compose -p fusionsuite-backend -f docker/docker-compose.yml up
+
+.PHONY: docker-clean
+docker-clean: ## Clean the Docker stuff
+	docker-compose -p fusionsuite-backend -f docker/docker-compose.yml down
+
+.PHONY: lint
+lint: ## Run the linter
+	$(PHP) ./vendor/bin/phpcs ./src ./public
+
+.PHONY: lint-fix
+lint-fix: ## Fix the errors detected by the linter
+	$(PHP) ./vendor/bin/phpcbf ./src ./public
+
+.PHONY: install
+install: ## Install the dependencies
+	$(COMPOSER) install
+	for dir in $(ACTIONSCRIPTS_DIRS); do \
+		$(COMPOSER) install --working-dir=$$dir; \
+	done
+
+.PHONY: setup
+setup: ## Setup the database
+	$(CLI) env:create -c \
+		-n $(ENV_NAME) \
+		-t $(DB_TYPE) \
+		-H $(DB_HOST) \
+		-d $(DB_NAME) \
+		-u $(DB_USER) \
+		-p $(DB_PASS) \
+		-P $(DB_PORT)
+	$(CLI) install
+
+.PHONY: help
+help:
+	@grep -h -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,15 @@
+FROM php:7.4-fpm
+
+ENV COMPOSER_HOME /tmp
+
+RUN apt-get update && apt-get install -y \
+    git \
+    libzip-dev \
+    unzip \
+  && pecl install xdebug \
+  && docker-php-ext-install -j$(nproc) zip pdo pdo_mysql \
+  && docker-php-ext-enable xdebug \
+  && echo "xdebug.mode=coverage" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini;
+
+COPY install-composer.sh .
+RUN sh ./install-composer.sh && rm ./install-composer.sh

--- a/docker/bin/cli
+++ b/docker/bin/cli
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+export COMPOSE_PROJECT_NAME=fusionsuite-backend
+export COMPOSE_FILE=docker/docker-compose.yml
+export USER=$(id -u):$(id -g)
+
+if [ -z `docker-compose ps -q php` ] || [ -z `docker ps -q --no-trunc | grep $(docker-compose ps -q php)` ]; then
+    docker-compose run --rm --no-deps php ./bin/cli "$@"
+else
+    docker-compose exec php ./bin/cli "$@"
+fi

--- a/docker/bin/composer
+++ b/docker/bin/composer
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+export COMPOSE_PROJECT_NAME=fusionsuite-backend
+export COMPOSE_FILE=docker/docker-compose.yml
+export USER=$(id -u):$(id -g)
+
+if [ -z `docker-compose ps -q php` ] || [ -z `docker ps -q --no-trunc | grep $(docker-compose ps -q php)` ]; then
+    docker-compose run --rm --no-deps php composer "$@"
+else
+    docker-compose exec php composer "$@"
+fi

--- a/docker/bin/mariadb
+++ b/docker/bin/mariadb
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+export COMPOSE_PROJECT_NAME=fusionsuite-backend
+export COMPOSE_FILE=docker/docker-compose.yml
+export USER=$(id -u):$(id -g)
+
+if [ -z `docker-compose ps -q database` ] || [ -z `docker ps -q --no-trunc | grep $(docker-compose ps -q database)` ]; then
+    docker-compose run --rm --no-deps database mariadb -u fusionsuite -p fusionsuite_development "$@"
+else
+    docker-compose exec database mariadb -u fusionsuite -p fusionsuite_development "$@"
+fi

--- a/docker/bin/php
+++ b/docker/bin/php
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+export COMPOSE_PROJECT_NAME=fusionsuite-backend
+export COMPOSE_FILE=docker/docker-compose.yml
+export USER=$(id -u):$(id -g)
+
+if [ -z `docker-compose ps -q php` ] || [ -z `docker ps -q --no-trunc | grep $(docker-compose ps -q php)` ]; then
+    docker-compose run --rm --no-deps php php "$@"
+else
+    docker-compose exec php php "$@"
+fi

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,43 @@
+version: '3'
+
+services:
+  php:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    ports:
+      - "9000:9000"
+    volumes:
+      - ..:/var/www/html:z
+      - composer:/tmp
+    user: $USER
+    links:
+      - database
+
+  nginx:
+    image: nginx:alpine
+    restart: unless-stopped
+    ports:
+        - "8000:8000"
+    volumes:
+        - ..:/var/www/html:z
+        - ./nginx.conf:/etc/nginx/conf.d/default.conf:z
+    links:
+        - php
+
+  database:
+    image: mariadb:10.7
+    restart: unless-stopped
+    environment:
+      - MARIADB_ROOT_PASSWORD=fusionsuite
+      - MARIADB_USER=fusionsuite
+      - MARIADB_PASSWORD=fusionsuite
+      - MARIADB_DATABASE=fusionsuite_development
+
+volumes:
+    composer: {}
+
+networks:
+  default:
+    name: fusionsuite-network

--- a/docker/install-composer.sh
+++ b/docker/install-composer.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# Code from https://getcomposer.org/doc/faqs/how-to-install-composer-programmatically.md
+
+EXPECTED_CHECKSUM="$(curl https://composer.github.io/installer.sig)"
+php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+ACTUAL_CHECKSUM="$(php -r "echo hash_file('sha384', 'composer-setup.php');")"
+
+if [ "$EXPECTED_CHECKSUM" != "$ACTUAL_CHECKSUM" ]
+then
+    >&2 echo 'ERROR: Invalid installer checksum'
+    rm composer-setup.php
+    exit 1
+fi
+
+php composer-setup.php --install-dir=/usr/local/bin --filename=composer
+RESULT=$?
+chmod +x /usr/local/bin/composer
+rm composer-setup.php
+exit $RESULT

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,0 +1,25 @@
+server {
+  listen 8000;
+  server_name localhost;
+
+  root /var/www/html/public;
+  index index.html index.php;
+
+  error_log  /var/log/nginx/error.log;
+  access_log /var/log/nginx/access.log;
+
+  location / {
+    fastcgi_pass php:9000;
+
+    fastcgi_param   SCRIPT_FILENAME $document_root/index.php$fastcgi_script_name;
+    include         fastcgi_params;
+
+    add_header      Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    add_header      X-Frame-Options "SAMEORIGIN";
+    add_header      Access-Control-Allow-Origin *;
+    add_header      Access-Control-Allow-Methods 'GET, POST, OPTIONS, PUT, DELETE';
+    add_header      Access-Control-Allow-Credentials true;
+    add_header      Access-Control-Allow-Headers 'Origin,Content-Type,Accept,Authorization,Cache-Control,Pragma,Expires';
+    add_header      Access-Control-Expose-Headers 'X-Total-Count,Content-Range,Link';
+  }
+}


### PR DESCRIPTION
Changes proposed in this pull request:

- provide Docker and docker-compose configuration to run the development environment
- provide a Makefile to setup the system (with or without Docker) → note that I plan to add a `make test` command later, but I'm not able to execute the tests yet (cf. https://github.com/fusionSuite/FusionSuite/issues/5)
- provide commands wrappers under `docker/bin/` to facilitate the work of developers

How to test the feature manually:

1. follow the instructions from https://github.com/fusionSuite/documentation/pull/27
2. verify you're able to setup the environment

Pull request checklist:

- [x] code is manually tested
- [x] tests are updated N/A
- [x] commit messages are relevant
- [x] documentation is updated (including code comments, commit messages…)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and precise `N/A` next to it._

Related to:

- https://github.com/fusionSuite/FusionSuite/issues/7
- https://github.com/fusionSuite/frontend/pull/23
- https://github.com/fusionSuite/documentation/pull/27
