### PR TITLE
fix: Fix the CI linter

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -23,6 +23,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
 
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
@@ -61,10 +63,12 @@ jobs:
       run: phpstan analyse ActionScripts
 
     - name: Run phpcs
-      run: phpcs -q --report=checkstyle src public | cs2pr
-
-    - name: Run phpcs on rule action scripts
-      run: phpcs -q --report=checkstyle --ignore="ActionScripts/*/vendor/*" ActionScripts | cs2pr
+      run: |
+        files=$(git diff --name-only --diff-filter=d origin/${{ github.base_ref }} | grep '^\(src\|public\|ActionScripts\)' || true)
+        if [ -n "$files" ]; then
+          phpcs -q --report=checkstyle $files | cs2pr
+        fi
+      if: github.event_name == 'pull_request'
 
   unit_tests:
 

--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -1,5 +1,14 @@
 <?xml version="1.0"?>
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHP_CodeSniffer" xsi:noNamespaceSchemaLocation="phpcs.xsd">
+    <exclude-pattern>ActionScripts/*/vendor/*</exclude-pattern>
+
+    <rule ref="PSR12">
+      <exclude name="Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace" />
+      <exclude name="Squiz.ControlStructures.ControlSignature.SpaceAfterCloseParenthesis" />
+      <exclude name="Squiz.Functions.MultiLineFunctionDeclaration.BraceOnNewLine" />
+      <exclude name="Squiz.Functions.MultiLineFunctionDeclaration.NewlineBeforeOpenBrace" />
+    </rule>
+
     <rule ref="Generic.Arrays.ArrayIndent">
         <properties>
             <property name="indent" value="2" />
@@ -11,13 +20,19 @@
             <property name="checkClosures" value="true" />
         </properties>
     </rule>
-    <rule ref="Generic.Functions.OpeningFunctionBraceKernighanRitchie">
+    <rule ref="Generic.WhiteSpace.ScopeIndent">
         <properties>
-            <property name="checkFunctions" value="false" />
-            <property name="checkClosures" value="false" />
+            <property name="indent" value="2" />
         </properties>
     </rule>
-    <rule ref="Generic.WhiteSpace.ScopeIndent">
+
+    <rule ref="PSR2.Methods.FunctionCallSignature">
+        <properties>
+            <property name="indent" value="2" />
+        </properties>
+    </rule>
+
+    <rule ref="Squiz.Functions.MultiLineFunctionDeclaration">
         <properties>
             <property name="indent" value="2" />
         </properties>


### PR DESCRIPTION
Changes proposed in this pull request:

- configure the default coding style standard to PSR12
- adapt the PSR12 to match with some of current style decisions
- configure the CI to only lint the files changed in the PR
- execute the linter only on pull requests

How to test the feature manually:

1. change a file under `src/`, `public/` or `ActionScripts/` with some style errors (e.g. 4-spaces indentation)
2. open a PR
3. check that the linter (`check_code` job) fails
4. check that the modified file has annotations in the PR "Files changed" tab

Pull request checklist:

- [x] code is manually tested
- [x] tests are updated N/A
- [x] commit messages are relevant
- [x] documentation is updated (including code comments, commit messages…)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and precise `N/A` next to it._

Related to https://github.com/fusionSuite/FusionSuite/issues/2