### PR TITLE
tec: Fix the linter for the else bracket

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -5,6 +5,7 @@
     <rule ref="PSR12">
       <exclude name="Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace" />
       <exclude name="Squiz.ControlStructures.ControlSignature.SpaceAfterCloseParenthesis" />
+      <exclude name="Squiz.ControlStructures.ControlSignature.SpaceAfterKeyword" />
       <exclude name="Squiz.Functions.MultiLineFunctionDeclaration.BraceOnNewLine" />
       <exclude name="Squiz.Functions.MultiLineFunctionDeclaration.NewlineBeforeOpenBrace" />
     </rule>


### PR DESCRIPTION
Changes proposed in this pull request:

- Fix the configuration of phpcs to accept the `else` bracket to be on a new line

How to test the feature manually:

1. Add somewhere:
    ```php
    if (true)
    {
    }
    else
    {
    }
    ```
2. check that the linter doesn't fail

Pull request checklist:

- [x] code is manually tested
- [x] tests are updated N/A
- [x] commit messages are relevant
- [x] documentation is updated (including code comments, commit messages…)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and precise `N/A` next to it._
