### PR TITLE
tec: Send CORS headers on errors in Docker Nginx config

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -15,11 +15,11 @@ server {
     include         fastcgi_params;
 
     add_header      Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-    add_header      X-Frame-Options "SAMEORIGIN";
-    add_header      Access-Control-Allow-Origin *;
-    add_header      Access-Control-Allow-Methods 'GET, POST, OPTIONS, PUT, DELETE';
-    add_header      Access-Control-Allow-Credentials true;
-    add_header      Access-Control-Allow-Headers 'Origin,Content-Type,Accept,Authorization,Cache-Control,Pragma,Expires';
-    add_header      Access-Control-Expose-Headers 'X-Total-Count,Content-Range,Link';
+    add_header      X-Frame-Options "SAMEORIGIN" always;
+    add_header      Access-Control-Allow-Origin * always;
+    add_header      Access-Control-Allow-Methods 'GET, POST, OPTIONS, PUT, DELETE' always;
+    add_header      Access-Control-Allow-Credentials true always;
+    add_header      Access-Control-Allow-Headers 'Origin,Content-Type,Accept,Authorization,Cache-Control,Pragma,Expires' always;
+    add_header      Access-Control-Expose-Headers 'X-Total-Count,Content-Range,Link' always;
   }
 }


### PR DESCRIPTION
Changes proposed in this pull request:

- Add `always` to the `add_header` directives in the Docker Nginx configuration (so CORS headers are always sent, even on errors) 

Reference: http://nginx.org/en/docs/http/ngx_http_headers_module.html#add_header

How to test the feature manually:

1. Run the backend with the Docker config
2. Open the frontend on the login page
3. Try to login with wrong credentials
4. Verify that an error is displayed saying credentials are wrong (before, nothing was displayed)

Pull request checklist:

- [x] code is manually tested
- [x] tests are updated N/A
- [x] commit messages are relevant
- [x] documentation is updated (including code comments, commit messages…)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and precise `N/A` next to it._
