### PR TITLE
Add internalname of properties when get one or all items

### DIFF
--- a/src/v1/Controllers/Item.php
+++ b/src/v1/Controllers/Item.php
@@ -71,6 +71,7 @@ final class Item
    * @apiSuccess {Object[]}        -.properties                    List of properties of the item.
    * @apiSuccess {Number}          -.properties.id                 The id of the property.
    * @apiSuccess {String}          -.properties.name               The name of the property.
+   * @apiSuccess {String}          -.properties.internalname       The internalname of the property.
    * @codingStandardsIgnoreStart because break apidocsjs
    * @apiSuccess {String="string","integer","decimal","text","boolean","datetime","date","time","number","itemlink","itemlinks","typelink","typelinks","propertylink","list","password","passwordhash"}  -.properties.valuetype   The type of value.
    * @codingStandardsIgnoreEnd
@@ -181,7 +182,7 @@ final class Item
                        ->where('sub_organization', true);
               });
       })
-      ->with('properties:id,name,valuetype,unit,organization_id', 'properties.listvalues');
+      ->with('properties:id,name,internalname,valuetype,unit,organization_id', 'properties.listvalues');
 
     $items = $this->paramFilters($paramsQuery, $items);
     // Example filter on property value
@@ -270,6 +271,7 @@ final class Item
    * @apiSuccess {Object[]}        properties                    List of properties of the item.
    * @apiSuccess {Number}          properties.id                 The id of the property.
    * @apiSuccess {String}          properties.name               The name of the property.
+   * @apiSuccess {String}          properties.internalname       The internalname of the property.
    * @codingStandardsIgnoreStart because break apidocsjs
    * @apiSuccess {String="string","integer","decimal","text","boolean","datetime","date","time","number","itemlink","itemlinks","typelink","typelinks","propertylink","list","password","passwordhash"}  properties.valuetype   The type of value.
    * @codingStandardsIgnoreEnd
@@ -362,7 +364,8 @@ final class Item
     $organizations = \App\v1\Common::getOrganizationsIds($token);
     $parentsOrganizations = \App\v1\Common::getParentsOrganizationsIds($token);
 
-    $item = \App\v1\Models\Item::with('properties:id,name,valuetype,unit,organization_id', 'properties.listvalues')
+    $item = \App\v1\Models\Item::
+      with('properties:id,name,internalname,valuetype,unit,organization_id', 'properties.listvalues')
       ->withTrashed()->find($args['id'])->makeVisible(['propertygroups']);
     if (is_null($item))
     {

--- a/tests/RESTAPI/items/2_type-items-GET.js
+++ b/tests/RESTAPI/items/2_type-items-GET.js
@@ -44,6 +44,7 @@ describe('items | Endpoint /v1/items/type/3 (GET all)', function() {
         if (property.id === global.propertyid) {
           $serialnumber = property;
         }
+        assert(is.string(property.internalname));
       }
       assert($serialnumber !== null, 'the item must have a property named serialnumber');
       assert(is.integer($serialnumber.id), 'the first property id must be an integer');

--- a/tests/performances/test.js
+++ b/tests/performances/test.js
@@ -1,0 +1,45 @@
+import http from 'k6/http';
+
+import { sleep } from 'k6';
+
+export const options = {
+
+  thresholds: {
+    http_req_failed: ['rate<0.01'], // http errors should be less than 1%
+    http_req_duration: ['p(95)<200'], // 95% of requests should be below 200ms
+  },
+};
+
+export function setup() {
+  const url = 'http://127.0.0.1/fusionsuite/backend/v1/token';
+
+  const params = {
+    headers: {
+      'Content-Type': 'application/json'
+    },
+  };
+
+  const payload = JSON.stringify({
+    login: 'admin',
+    password: 'admin',
+  });
+
+  const res = http.post(url, payload, params);
+  return res.json();
+}
+
+export default function (data) {
+
+  const url = 'http://127.0.0.1/fusionsuite/backend/v1/config/types/3';
+
+  const params = {
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': 'Bearer '+data.token
+    },
+  };
+
+  http.get(url, params);
+
+  sleep(1);
+}


### PR DESCRIPTION
Changes proposed in this pull request:

- return internalname in properties part of item(s)

How to test the feature manually:

1. get items and see in properties an attribute `internalname`

Pull request checklist:

- [x] code is manually tested
- [x] tests are updated
- [x] commit messages are relevant
- [x] documentation is updated (including code comments, commit messages…)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and precise `N/A` next to it._

Related to #
