### PR TITLE
Add a command to reset database & fix Docker binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,10 @@ setup: ## Setup the database
 		-P $(DB_PORT)
 	$(CLI) install
 
+.PHONY: db-reset
+db-reset: ## Reset the database
+	$(CLI) reset
+
 .PHONY: help
 help:
 	@grep -h -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/bin/cli
+++ b/bin/cli
@@ -36,5 +36,6 @@ $app->add(new \App\v1\Controllers\Cli\EnvironmentCreate);
 $app->add(new \App\v1\Controllers\Cli\EnvironmentList);
 $app->add(new \App\v1\Controllers\Cli\EnvironmentSwitch);
 $app->add(new \App\v1\Controllers\Cli\Install);
+$app->add(new \App\v1\Controllers\Cli\Reset);
 
 $app->handle($_SERVER['argv']);

--- a/docker/bin/cli
+++ b/docker/bin/cli
@@ -1,11 +1,12 @@
 #!/bin/bash
 
+SCRIPT_PATH=$(dirname $(realpath -s $0))
 export COMPOSE_PROJECT_NAME=fusionsuite-backend
-export COMPOSE_FILE=docker/docker-compose.yml
+export COMPOSE_FILE=$SCRIPT_PATH/../docker-compose.yml
 export USER=$(id -u):$(id -g)
 
 if [ -z `docker-compose ps -q php` ] || [ -z `docker ps -q --no-trunc | grep $(docker-compose ps -q php)` ]; then
-    docker-compose run --rm --no-deps php ./bin/cli "$@"
+    docker-compose run -T --rm --no-deps php ./bin/cli "$@"
 else
-    docker-compose exec php ./bin/cli "$@"
+    docker-compose exec -T php ./bin/cli "$@"
 fi

--- a/docker/bin/composer
+++ b/docker/bin/composer
@@ -1,11 +1,12 @@
 #!/bin/bash
 
+SCRIPT_PATH=$(dirname $(realpath -s $0))
 export COMPOSE_PROJECT_NAME=fusionsuite-backend
-export COMPOSE_FILE=docker/docker-compose.yml
+export COMPOSE_FILE=$SCRIPT_PATH/../docker-compose.yml
 export USER=$(id -u):$(id -g)
 
 if [ -z `docker-compose ps -q php` ] || [ -z `docker ps -q --no-trunc | grep $(docker-compose ps -q php)` ]; then
-    docker-compose run --rm --no-deps php composer "$@"
+    docker-compose run -T --rm --no-deps php composer "$@"
 else
-    docker-compose exec php composer "$@"
+    docker-compose exec -T php composer "$@"
 fi

--- a/docker/bin/mariadb
+++ b/docker/bin/mariadb
@@ -1,11 +1,12 @@
 #!/bin/bash
 
+SCRIPT_PATH=$(dirname $(realpath -s $0))
 export COMPOSE_PROJECT_NAME=fusionsuite-backend
-export COMPOSE_FILE=docker/docker-compose.yml
+export COMPOSE_FILE=$SCRIPT_PATH/../docker-compose.yml
 export USER=$(id -u):$(id -g)
 
 if [ -z `docker-compose ps -q database` ] || [ -z `docker ps -q --no-trunc | grep $(docker-compose ps -q database)` ]; then
-    docker-compose run --rm --no-deps database mariadb -u fusionsuite -p fusionsuite_development "$@"
+    docker-compose run --rm --no-deps database mariadb -u fusionsuite --password=fusionsuite fusionsuite_development "$@"
 else
-    docker-compose exec database mariadb -u fusionsuite -p fusionsuite_development "$@"
+    docker-compose exec database mariadb -u fusionsuite --password=fusionsuite fusionsuite_development "$@"
 fi

--- a/docker/bin/php
+++ b/docker/bin/php
@@ -1,11 +1,12 @@
 #!/bin/bash
 
+SCRIPT_PATH=$(dirname $(realpath -s $0))
 export COMPOSE_PROJECT_NAME=fusionsuite-backend
-export COMPOSE_FILE=docker/docker-compose.yml
+export COMPOSE_FILE=$SCRIPT_PATH/../docker-compose.yml
 export USER=$(id -u):$(id -g)
 
 if [ -z `docker-compose ps -q php` ] || [ -z `docker ps -q --no-trunc | grep $(docker-compose ps -q php)` ]; then
-    docker-compose run --rm --no-deps php php "$@"
+    docker-compose run -T --rm --no-deps php php "$@"
 else
-    docker-compose exec php php "$@"
+    docker-compose exec -T php php "$@"
 fi

--- a/src/v1/Controllers/Cli/Reset.php
+++ b/src/v1/Controllers/Cli/Reset.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * FusionSuite - Backend
+ * Copyright (C) 2022 FusionSuite
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace App\v1\Controllers\Cli;
+
+use Ahc\Cli\Input\Command;
+use Ahc\Cli\Output\Writer;
+use Illuminate\Database\Capsule\Manager as Capsule;
+use Illuminate\Events\Dispatcher;
+use Illuminate\Container\Container;
+
+class Reset extends Command
+{
+  public function __construct()
+  {
+    parent::__construct('reset', 'Reset the database');
+  }
+
+  public function execute()
+  {
+    $writer = new Writer();
+    $writer->comment('=> The database will be reset', true);
+
+    $config = include(__DIR__ . '/../../../config.php');
+
+    $capsule = new Capsule();
+    $capsule->addConnection($config['db']);
+    $capsule->setEventDispatcher(new Dispatcher(new Container()));
+    $capsule->setAsGlobal();
+    $capsule->bootEloquent();
+
+    $database_name = $config['db']['database'];
+
+    $writer->green(' -> Droping the tables ');
+
+    try {
+      Capsule::schema()->dropAllTables();
+      $writer->boldGreen('OK', true);
+    } catch (\Exception $e) {
+      $writer->boldRed('Failed', true);
+      $writer->error($e->getMessage(), true);
+      return -1;
+    }
+
+    $install_command = new Install();
+    return $install_command->execute();
+  }
+}


### PR DESCRIPTION
This will allow us to reset the database from Cypress.

Changes proposed in this pull request:

- Add a command `cli reset` to reset the database (drop & recreate the database, which need specific permissions) (→ only tested with MariaDB, but the SQL queries are the same with PostgreSQL so I expect it to work)
- Add a command to reset the DB in the Makefile
- Allow to execute the Docker binaries from any location (no need to `cd` in the root directory)
- Don't allocate a TTY when calling docker-compose (except for mariadb or it would fail).
- Pass the password to the Docker mariadb command so we don't always have to type it

How to test the feature manually:

1. create some data in the database
2. call `make db-reset` or `php cli reset`
3. verify the database has been reset

Pull request checklist:

- [x] code is manually tested
- [x] tests are updated N/A
- [x] commit messages are relevant
- [x] documentation is updated (including code comments, commit messages…)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and precise `N/A` next to it._

Related to https://github.com/fusionSuite/frontend/pull/28
