### PR TITLE
Add auditlogs feature

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -204,6 +204,11 @@ jobs:
         cd tests/RESTAPI/
         ./node_modules/.bin/mb --configfile mountebank/imposters.ejs &
 
+    - name: run php server to act on database
+      run: |
+        cd tests/RESTAPI/
+        php -S 127.0.0.1:8012 testDatabaseAccess.php &
+
     - name: run REST API tests
       run: |
         cd tests/RESTAPI/
@@ -302,6 +307,11 @@ jobs:
         cd tests/RESTAPI/
         ./node_modules/.bin/mb --configfile mountebank/imposters.ejs &
 
+    - name: run php server to act on database
+      run: |
+        cd tests/RESTAPI/
+        php -S 127.0.0.1:8012 testDatabaseAccess.php &
+
     - name: run REST API tests
       run: |
         cd tests/RESTAPI/
@@ -398,6 +408,11 @@ jobs:
       run: |
         cd tests/RESTAPI/
         ./node_modules/.bin/mb --configfile mountebank/imposters.ejs &
+
+    - name: run php server to act on database
+      run: |
+        cd tests/RESTAPI/
+        php -S 127.0.0.1:8012 testDatabaseAccess.php &
 
     - name: run REST API tests
       run: |

--- a/db/migrations/20220918075728_audit.php
+++ b/db/migrations/20220918075728_audit.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * FusionSuite - Frontend
+ * Copyright (C) 2022 FusionSuite
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class Audit extends AbstractMigration
+{
+  /**
+   * Change Method.
+   *
+   * Write your reversible migrations using this method.
+   *
+   * More information on writing migrations is available here:
+   * https://book.cakephp.org/phinx/0/en/migrations.html#the-change-method
+   *
+   * Remember to call "create()" or "update()" and NOT "save()" when working
+   * with the Table class.
+   */
+  public function change(): void
+  {
+    // create the table
+    $table = $this->table('audits');
+    $table->addColumn('userid', 'integer', ['null' => true])
+          ->addColumn('username', 'string', ['null' => true])
+          ->addColumn('ip', 'string', ['null' => true])
+          ->addColumn('httpmethod', 'string', ['null' => true])
+          ->addColumn('endpoint', 'string', ['null' => true])
+          ->addColumn('httpcode', 'integer', ['null' => true])
+          ->addColumn('action', 'string')
+          ->addColumn('model', 'string', ['null' => true])
+          ->addColumn('item_id', 'integer', ['null' => true])
+          ->addColumn('message', 'string')
+          ->addColumn('created_at', 'datetime')
+          ->create();
+  }
+}

--- a/src/Route.php
+++ b/src/Route.php
@@ -193,6 +193,15 @@ final class Route
           });
         });
       });
+
+      $v1->group("/log", function (RouteCollectorProxy $log)
+      {
+        $log->group("/audits", function (RouteCollectorProxy $properties)
+        {
+          $properties->map(['GET'], '', \App\v1\Controllers\Log\Audit::class . ':getAll');
+        });
+      });
+
       $v1->group("/rules/{type:searchitem|rewritefield|actionscript}", function (RouteCollectorProxy $rule)
       {
         $rule->map(['GET'], '', \App\v1\Controllers\Rule::class . ':getAll');

--- a/src/v1/Controllers/Config/Type.php
+++ b/src/v1/Controllers/Config/Type.php
@@ -352,6 +352,8 @@ final class Type
 
     $type = $this->createType($data, $token);
 
+    \App\v1\Controllers\Log\Audit::addEntry($request, 'CREATE', '', 'Config\Type', $type->id);
+
     $response->getBody()->write(json_encode(["id" => intval($type->id)]));
     return $response->withHeader('Content-Type', 'application/json');
   }
@@ -412,9 +414,18 @@ final class Type
     }
     if ($type->trashed())
     {
+      \App\v1\Controllers\Log\Audit::addEntry(
+        $request,
+        'SOFTDELETE',
+        'restore',
+        'Config\Type',
+        $type->id
+      );
       $type->restore();
+    } else {
+      \App\v1\Controllers\Log\Audit::addEntry($request, 'UPDATE', '', 'Config\Type', $type->id);
+      $type->save();
     }
-    $type->save();
 
     $response->getBody()->write(json_encode([]));
     return $response->withHeader('Content-Type', 'application/json');
@@ -457,6 +468,7 @@ final class Type
       // check permissions
       \App\v1\Permission::checkPermissionToStructure('delete', 'config/type', $type->id);
 
+      \App\v1\Controllers\Log\Audit::addEntry($request, 'DELETE', '', 'Config\Type', $type->id);
       $type->forceDelete();
 
       // Post delete actions
@@ -467,6 +479,7 @@ final class Type
       // check permissions
       \App\v1\Permission::checkPermissionToStructure('softdelete', 'config/type', $type->id);
 
+      \App\v1\Controllers\Log\Audit::addEntry($request, 'SOFTDELETE', '', 'Config\Type', $type->id);
       $type->properties()->detach();
       $type->delete();
     }

--- a/src/v1/Controllers/Log/Audit.php
+++ b/src/v1/Controllers/Log/Audit.php
@@ -1,0 +1,127 @@
+<?php
+
+/**
+ * FusionSuite - Backend
+ * Copyright (C) 2022 FusionSuite
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace App\v1\Controllers\Log;
+
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use stdClass;
+
+final class Audit
+{
+  use \App\v1\Read;
+
+  /**
+   * @api {get} /v1/log/audits Get all audits logs
+   * @apiName GetLogAudits
+   * @apiGroup Log/Audits
+   * @apiVersion 1.0.0-draft
+   *
+   * @apiUse AutorizationHeader
+   *
+   * @apiSuccess {Object[]}      logs                  List of audits logs.
+   * @apiSuccess {Number}        logs.id               The id of the audit log.
+   * @apiSuccess {null|String}   logs.username         The name of the user has made the action.
+   * @apiSuccess {String}        logs.ip               The IP address of the user has made the action.
+   * @apiSuccess {String="GET","POST","PATCH","DELETE"}   logs.httpmethod    The HTTP method of the REST API request.
+   * @apiSuccess {String}        logs.endpoint         The endpoint of the REST API request.
+   * @apiSuccess {Number}        logs.httpcode         The HTTP code returned by the backend.
+   * @apiSuccess {String}        logs.action           The action name like CONNECTION, CREATE...
+   * @apiSuccess {null|String}   logs.model            The model used.
+   * @apiSuccess {null|Number}   logs.item_id          The id of the item concerned (to be linked with model).
+   * @apiSuccess {String}        logs.message          The message for more information.
+   * @apiSuccess {ISO8601}       logs.created_at       Date of the creation.
+   * @apiSuccess {null|Object}   logs.user             User do the action.
+   * @apiSuccess {Number}        logs.user.id          Id of the user who did the action.
+   * @apiSuccess {String}        logs.user.name        Name (login) of the user who did the action.
+   * @apiSuccess {String}        logs.user.first_name  First name of the user who did the action.
+   * @apiSuccess {String}        logs.user.last_name   Last name of the user who did the action.
+   *
+   * @apiSuccessExample Success-Response:
+   * HTTP/1.1 200 OK
+   * [
+   *   {
+   *     "id": 2,
+   *     "username": "admin",
+   *     "ip": "192.168.1.82",
+   *     "httpmethod": "POST",
+   *     "endpoint": "/fusionsuite/backend/v1/token",
+   *     "httpcode": 200,
+   *     "action": "CONNECTION",
+   *     "model": "User",
+   *     "item_id": 2,
+   *     "message": "",
+   *     "created_at": "2022-10-02T06:16:42.000000Z",
+   *     "user": {
+   *       "id": 2,
+   *       "name": "admin",
+   *       "first_name": "Steve",
+   *       "last_name": "Rogers"
+   *     }
+   *   }
+   * ]
+   *
+   */
+  public function getAll(Request $request, Response $response, $args): Response
+  {
+    $token = (object)$request->getAttribute('token');
+
+    $paramsQuery = $request->getQueryParams();
+    $pagination = $this->paramPagination($paramsQuery);
+
+    $params = $this->manageParams($request);
+
+    $logs = \App\v1\Models\Log\Audit::ofSort($params);
+    $logs = $this->paramFilters($paramsQuery, $logs);
+    $totalCnt = $logs->count();
+    $logs->skip(($params['skip'] * $params['take']))->take($params['take']);
+    $allLogs = $logs->get();
+
+    $response->getBody()->write($allLogs->toJson());
+    $response = $response->withAddedHeader('X-Total-Count', $totalCnt);
+    $response = $response->withAddedHeader('Link', $this->createLink($request, $pagination, $totalCnt));
+    $response = $response->withAddedHeader(
+      'Content-Range',
+      $this->createContentRange($request, $pagination, $totalCnt)
+    );
+    return $response->withHeader('Content-Type', 'application/json');
+  }
+
+  public static function addEntry(Request $request, $action, $message, $model, $itemId, $httpcode = 200)
+  {
+    $audit = new \App\v1\Models\Log\Audit();
+    if (!is_null($GLOBALS['user_id']))
+    {
+      $audit->userid = $GLOBALS['user_id'];
+      $user = \App\v1\Models\Item::find($GLOBALS['user_id']);
+      // Store the name in case the user account deleted later
+      $audit->username = $user->name;
+    }
+    $audit->ip = $request->getServerParams()['REMOTE_ADDR'];
+    $audit->endpoint = $request->getUri()->getPath();
+    $audit->httpmethod = $request->getMethod();
+    $audit->httpcode = $httpcode;
+    $audit->action = $action;
+    $audit->model = $model;
+    $audit->item_id = $itemId;
+    $audit->message = $message;
+    $audit->save();
+  }
+}

--- a/src/v1/Controllers/Token.php
+++ b/src/v1/Controllers/Token.php
@@ -195,6 +195,9 @@ final class Token
       "refreshtoken" => $refreshtoken,
       "expires"      => $future->getTimeStamp()
     ];
+    $GLOBALS['user_id'] = $user->id;
+    \App\v1\Controllers\Log\Audit::addEntry($request, 'CONNECTION', '', 'User', $user->id);
+
     $response->getBody()->write(json_encode($responseData, JSON_UNESCAPED_SLASHES));
     return $response->withHeader("Content-Type", "application/json");
   }

--- a/src/v1/Models/Log/Audit.php
+++ b/src/v1/Models/Log/Audit.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * FusionSuite - Backend
+ * Copyright (C) 2022 FusionSuite
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace App\v1\Models\Log;
+
+use Illuminate\Database\Eloquent\Model as Model;
+
+class Audit extends Model
+{
+  // disable UPDATED_AT because will have only write in this table
+  public const UPDATED_AT = null;
+
+  protected $appends = [
+    'user'
+  ];
+  protected $visible = [
+    'id',
+    'user',
+    'username',
+    'ip',
+    'httpmethod',
+    'endpoint',
+    'httpcode',
+    'action',
+    'model',
+    'item_id',
+    'message',
+    'created_at'
+  ];
+
+  public function getUserAttribute()
+  {
+    return \App\v1\Models\Common::getUserAttributes($this->attributes['userid']);
+  }
+
+  public function scopeofSort($query, $params)
+  {
+    return \App\v1\Models\Common::scopeofSort($query, $params);
+  }
+}

--- a/tests/RESTAPI/17_logAudit/1_connection.js
+++ b/tests/RESTAPI/17_logAudit/1_connection.js
@@ -1,0 +1,137 @@
+const supertest = require('supertest');
+const validator = require('validator');
+const assert = require('assert');
+const is = require('is_js');
+
+const request = supertest('http://127.0.0.1/fusionsuite/backend');
+const requestDB = supertest('http://127.0.0.1:8012');
+
+describe('logAudit | log connections', function() {
+  it('truncate audits database table', function(done) {
+    requestDB
+    .get('/truncate/audits')
+    .expect(200)
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it('do a successfully login', function(done) {
+    request
+    .post('/v1/token')
+    .send({login: 'admin', password: 'admin'})
+    .set('Accept', 'application/json')
+    .expect(200)
+    .expect('Content-Type', /json/)
+    .expect(function(response) {
+      assert(is.propertyCount(response.body, 3));
+
+      assert(validator.isJWT(response.body.token));
+      assert(validator.matches(response.body.refreshtoken, /^\w+$/));
+
+      assert(is.integer(response.body.expires));
+      assert(validator.matches('' + response.body.expires, /^\d{10}$/));
+      global.token = response.body.token;
+    })
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it('do a failed login with unknow user', function(done) {
+    request
+    .post('/v1/token')
+    .send({login: 'adminfjewrighrw', password: 'admin'})
+    .set('Accept', 'application/json')
+    .expect(401)
+    .expect('Content-Type', /json/)
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it('do a query with malformed token', function(done) {
+    request
+    .get('/v1/config/types')
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer eyJ0eXAiOiJKV1QLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE2NjM2MTcyMzQsImV4cCI6MTY2MzYxODQzNCwianRpIjoiIiwic3ViIjoiIiwic2NvcGUiOltdLCJ1c2VyX2lkIjoyLCJmaXJzdG5hbWUiOiJTdGV2ZSIsImxhc3RuYW1lIjoiUm9nZXJzIiwiYXBpdmVyc2lvbiI6InYxIiwib3JnYW5pemF0aW9uX2lkIjoxLCJzdWJfb3JnYW5pemF0aW9uIjp0cnVlfQ.NuHFCoaVVLPWq_Zydq6XdqPVO9VkF0mmtRwLhRNArGk')
+    .expect(401)
+    .expect('Content-Type', /json/)
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it('do a query with wrong signature in token', function(done) {
+    request
+    .get('/v1/config/types')
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE2NjM2MTcyMzQsImV4cCI6MTY2MzYxODQzNCwianRpIjoiIiwic3ViIjoiIiwic2NvcGUiOltdLCJ1c2VyX2lkIjoyLCJmaXJzdG5hbWUiOiJTdGV2ZSIsImxhc3RuYW1lIjoiUm9nZXJzIiwiYXBpdmVyc2lvbiI6InYxIiwib3JnYW5pemF0aW9uX2lkIjoxLCJzdWJfb3JnYW5pemF0aW9uIjp0cnVlfQ.NuHFCoaVVLPWq_Zydq6XdqPVO9VkF0mmtRwLhRNArgk')
+    .expect(401)
+    .expect('Content-Type', /json/)
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+
+  it('verify audits added', function(done) {
+    request
+    .get('/v1/log/audits')
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(200)
+    .expect('Content-Type', /json/)
+    .expect(function(response) {
+      assert(is.not.empty(response.body));
+      assert(is.array(response.body));
+      assert(is.equal(4, response.body.length));
+
+      successLogin = response.body[0];
+      assert(is.equal(200, successLogin.httpcode));
+      assert(is.equal('', successLogin.message));
+      assert(validator.isISO8601(successLogin.created_at), 'the log created_at must be a valid ISO8601 date');
+      assert(is.object(successLogin.user));
+      assert(is.equal(2, successLogin.user.id));
+      assert(is.equal('admin', successLogin.user.name));
+      assert(is.equal('Steve', successLogin.user.first_name));
+      assert(is.equal('Rogers', successLogin.user.last_name));
+
+      failLogin = response.body[1];
+      assert(is.equal(401, failLogin.httpcode));
+      assert(is.equal('fail, login: adminfjewrighrw', failLogin.message));
+
+      malformedToken = response.body[2];
+      assert(is.equal(401, malformedToken.httpcode));
+      assert(is.equal('Unexpected control character found', malformedToken.message));
+
+      badSignatureToken = response.body[3];
+      assert(is.equal(401, badSignatureToken.httpcode));
+      assert(is.equal('Signature verification failed', badSignatureToken.message));
+
+    })
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+});
+

--- a/tests/RESTAPI/17_logAudit/2_property.js
+++ b/tests/RESTAPI/17_logAudit/2_property.js
@@ -1,0 +1,292 @@
+const supertest = require('supertest');
+const validator = require('validator');
+const assert = require('assert');
+const is = require('is_js');
+
+const request = supertest('http://127.0.0.1/fusionsuite/backend');
+const requestDB = supertest('http://127.0.0.1:8012');
+
+describe('logAudit | log property actions', function() {
+  it('truncate audits database table', function(done) {
+    requestDB
+    .get('/truncate/audits')
+    .expect(200)
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it('create a property', function(done) {
+    request
+    .post('/v1/config/properties')
+    .send({
+      name: 'myprop1',
+      internalname: 'testformypropone',
+      organization_id: 1,
+      valuetype: 'string',
+      listvalues: [],
+      default: ''
+    })
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(200)
+    .expect('Content-Type', /json/)
+    .expect(function(response) {
+      assert(is.propertyCount(response.body, 1));
+      assert(is.integer(response.body.id));
+      assert(validator.matches('' + response.body.id, /^\d+$/));
+      global.myprop1 = response.body.id;
+    })
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it('create a property with wrong values', function(done) {
+    request
+    .post('/v1/config/properties')
+    .send({
+      name: 'myprop1',
+      internalname: 'testformypropone%t',
+      organization_id: 1,
+      valuetype: true,
+      listvalues: [],
+      default: ''
+    })
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(400)
+    .expect('Content-Type', /json/)
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it('view a property', function(done) {
+    request
+    .get('/v1/config/properties/'+global.myprop1)
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(200)
+    .expect('Content-Type', /json/)
+    .expect(function(response) {
+      assert(is.not.empty(response.body));
+      assert(is.equal('myprop1', response.body.name));
+    })
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it('view a property does not exists', function(done) {
+    request
+    .get('/v1/config/properties/300000')
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(404)
+    .expect('Content-Type', /json/)
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it('update a property', function(done) {
+    request
+    .patch('/v1/config/properties/'+global.myprop1)
+    .send({
+      name: 'test patch'
+    })
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(200)
+    .expect('Content-Type', /json/)
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it('update a property with error', function(done) {
+    request
+    .patch('/v1/config/properties/'+global.myprop1)
+    .send({
+      setcurrentdate: 'string instead boolean'
+    })
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(400)
+    .expect('Content-Type', /json/)
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it('softdelete a property', function(done) {
+    request
+    .delete('/v1/config/properties/'+global.myprop1)
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(200)
+    .expect('Content-Type', /json/)
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it('restore a property', function(done) {
+    request
+    .patch('/v1/config/properties/'+global.myprop1)
+    .send({
+    })
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(200)
+    .expect('Content-Type', /json/)
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it('softdelete a property', function(done) {
+    request
+    .delete('/v1/config/properties/'+global.myprop1)
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(200)
+    .expect('Content-Type', /json/)
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it('delete a property', function(done) {
+    request
+    .delete('/v1/config/properties/'+global.myprop1)
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(200)
+    .expect('Content-Type', /json/)
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it('delete a property does not exists', function(done) {
+    request
+    .delete('/v1/config/properties/30000000')
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(404)
+    .expect('Content-Type', /json/)
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it('verify audits added', function(done) {
+    request
+    .get('/v1/log/audits')
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(200)
+    .expect('Content-Type', /json/)
+    .expect(function(response) {
+      assert(is.not.empty(response.body));
+      assert(is.array(response.body));
+      assert(is.equal(10, response.body.length));
+
+      createProperty = response.body[0];
+      assert(is.equal(200, createProperty.httpcode));
+      assert(is.equal('CREATE', createProperty.action));
+      assert(is.equal('', createProperty.message));
+
+      failCreateProperty = response.body[1];
+      assert(is.equal(400, failCreateProperty.httpcode));
+      // assert(is.equal('CREATE', failCreateProperty.action));
+      assert(is.equal('The Internalname is not valid format, The Valuetype is not valid type', failCreateProperty.message));
+
+      viewNotexistsProperty = response.body[2];
+      assert(is.equal(404, viewNotexistsProperty.httpcode));
+      // assert(is.equal('VIEW', viewNotexistsProperty.action));
+      assert(is.equal('This item has not be found', viewNotexistsProperty.message));
+
+      updateProperty = response.body[3];
+      assert(is.equal(200, updateProperty.httpcode));
+      assert(is.equal('UPDATE', updateProperty.action));
+      assert(is.equal('', updateProperty.message));
+
+      failUpdateProperty = response.body[4];
+      assert(is.equal(400, failUpdateProperty.httpcode));
+      // assert(is.equal('UPDATE', failUpdateProperty.action));
+      assert(is.equal('The Setcurrentdate is not valid type', failUpdateProperty.message));
+
+      softdeleteProperty = response.body[5];
+      assert(is.equal(200, softdeleteProperty.httpcode));
+      assert(is.equal('SOFTDELETE', softdeleteProperty.action));
+      assert(is.equal('', softdeleteProperty.message));
+
+      restoreProperty = response.body[6];
+      assert(is.equal(200, restoreProperty.httpcode));
+      assert(is.equal('SOFTDELETE', restoreProperty.action));
+      assert(is.equal('restore', restoreProperty.message));
+
+      softdeletePropertyBis = response.body[7];
+      assert(is.equal(200, softdeletePropertyBis.httpcode));
+      assert(is.equal('SOFTDELETE', softdeletePropertyBis.action));
+      assert(is.equal('', softdeletePropertyBis.message));
+
+      deleteProperty = response.body[8];
+      assert(is.equal(200, deleteProperty.httpcode));
+      assert(is.equal('DELETE', deleteProperty.action));
+      assert(is.equal('', deleteProperty.message));
+
+      faildeleteProperty = response.body[9];
+      assert(is.equal(404, faildeleteProperty.httpcode));
+      // assert(is.equal('DELETE', faildeleteProperty.action));
+      assert(is.equal('The property has not be found', faildeleteProperty.message));
+
+    })
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+});

--- a/tests/RESTAPI/17_logAudit/3_type.js
+++ b/tests/RESTAPI/17_logAudit/3_type.js
@@ -1,0 +1,283 @@
+const supertest = require('supertest');
+const validator = require('validator');
+const assert = require('assert');
+const is = require('is_js');
+
+const request = supertest('http://127.0.0.1/fusionsuite/backend');
+const requestDB = supertest('http://127.0.0.1:8012');
+
+describe('logAudit | log type actions', function() {
+  it('truncate audits database table', function(done) {
+    requestDB
+    .get('/truncate/audits')
+    .expect(200)
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it('create a type', function(done) {
+    request
+    .post('/v1/config/types')
+    .send({
+      name: 'mytype1',
+    })
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(200)
+    .expect('Content-Type', /json/)
+    .expect(function(response) {
+      assert(is.propertyCount(response.body, 1));
+      assert(is.integer(response.body.id));
+      assert(validator.matches('' + response.body.id, /^\d+$/));
+      global.mytype1 = response.body.id;
+    })
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it('create a type with wrong values', function(done) {
+    request
+    .post('/v1/config/types')
+    .send({
+      name: 'mytype1',
+      organization_id: 'testformytypeone'
+    })
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(400)
+    .expect('Content-Type', /json/)
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it('view a type', function(done) {
+    request
+    .get('/v1/config/types/'+global.mytype1)
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(200)
+    .expect('Content-Type', /json/)
+    .expect(function(response) {
+      assert(is.not.empty(response.body));
+      assert(is.equal('mytype1', response.body.name));
+    })
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it('view a type does not exists', function(done) {
+    request
+    .get('/v1/config/types/300000')
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(404)
+    .expect('Content-Type', /json/)
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it('update a type', function(done) {
+    request
+    .patch('/v1/config/types/'+global.mytype1)
+    .send({
+      name: 'test patch'
+    })
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(200)
+    .expect('Content-Type', /json/)
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it('update a type with error', function(done) {
+    request
+    .patch('/v1/config/types/'+global.mytype1)
+    .send({
+      name: true
+    })
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(400)
+    .expect('Content-Type', /json/)
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it('softdelete a type', function(done) {
+    request
+    .delete('/v1/config/types/'+global.mytype1)
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(200)
+    .expect('Content-Type', /json/)
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it('restore a type', function(done) {
+    request
+    .patch('/v1/config/types/'+global.mytype1)
+    .send({
+    })
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(200)
+    .expect('Content-Type', /json/)
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it('softdelete a type', function(done) {
+    request
+    .delete('/v1/config/types/'+global.mytype1)
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(200)
+    .expect('Content-Type', /json/)
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it('delete a type', function(done) {
+    request
+    .delete('/v1/config/types/'+global.mytype1)
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(200)
+    .expect('Content-Type', /json/)
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it('delete a type does not exists', function(done) {
+    request
+    .delete('/v1/config/types/30000000')
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(404)
+    .expect('Content-Type', /json/)
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it('verify audits added', function(done) {
+    request
+    .get('/v1/log/audits')
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(200)
+    .expect('Content-Type', /json/)
+    .expect(function(response) {
+      assert(is.not.empty(response.body));
+      assert(is.array(response.body));
+      assert(is.equal(10, response.body.length));
+
+      createType = response.body[0];
+      assert(is.equal(200, createType.httpcode));
+      assert(is.equal('CREATE', createType.action));
+      assert(is.equal('', createType.message));
+
+      failCreateType = response.body[1];
+      assert(is.equal(400, failCreateType.httpcode));
+      // assert(is.equal('CREATE', failCreateType.action));
+      assert(is.equal('The Organization id is not valid type, The Organization id must be integer', failCreateType.message));
+
+      viewNotexistsType = response.body[2];
+      assert(is.equal(404, viewNotexistsType.httpcode));
+      // assert(is.equal('VIEW', viewNotexistsType.action));
+      assert(is.equal('This type has not be found', viewNotexistsType.message));
+
+      updateType = response.body[3];
+      assert(is.equal(200, updateType.httpcode));
+      assert(is.equal('UPDATE', updateType.action));
+      assert(is.equal('', updateType.message));
+
+      failUpdateType = response.body[4];
+      assert(is.equal(400, failUpdateType.httpcode));
+      // assert(is.equal('UPDATE', failUpdateType.action));
+      assert(is.equal('The Name is not valid type', failUpdateType.message));
+
+      softdeleteType = response.body[5];
+      assert(is.equal(200, softdeleteType.httpcode));
+      assert(is.equal('SOFTDELETE', softdeleteType.action));
+      assert(is.equal('', softdeleteType.message));
+
+      restoreType = response.body[6];
+      assert(is.equal(200, restoreType.httpcode));
+      assert(is.equal('SOFTDELETE', restoreType.action));
+      assert(is.equal('restore', restoreType.message));
+
+      softdeleteTypeBis = response.body[7];
+      assert(is.equal(200, softdeleteTypeBis.httpcode));
+      assert(is.equal('SOFTDELETE', softdeleteTypeBis.action));
+      assert(is.equal('', softdeleteTypeBis.message));
+
+      deleteType = response.body[8];
+      assert(is.equal(200, deleteType.httpcode));
+      assert(is.equal('DELETE', deleteType.action));
+      assert(is.equal('', deleteType.message));
+
+      faildeleteType = response.body[9];
+      assert(is.equal(404, faildeleteType.httpcode));
+      // assert(is.equal('DELETE', faildeleteType.action));
+      assert(is.equal('The type has not be found', faildeleteType.message));
+
+    })
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+});

--- a/tests/RESTAPI/17_logAudit/4_item.js
+++ b/tests/RESTAPI/17_logAudit/4_item.js
@@ -1,0 +1,284 @@
+const supertest = require('supertest');
+const validator = require('validator');
+const assert = require('assert');
+const is = require('is_js');
+
+const request = supertest('http://127.0.0.1/fusionsuite/backend');
+const requestDB = supertest('http://127.0.0.1:8012');
+
+describe('logAudit | log item actions', function() {
+  it('truncate audits database table', function(done) {
+    requestDB
+    .get('/truncate/audits')
+    .expect(200)
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it('create a item', function(done) {
+    request
+    .post('/v1/items')
+    .send({
+      name: 'myitem1',
+      type_id: 3
+    })
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(200)
+    .expect('Content-Type', /json/)
+    .expect(function(response) {
+      assert(is.propertyCount(response.body, 2));
+      assert(is.integer(response.body.id));
+      assert(validator.matches('' + response.body.id, /^\d+$/));
+      global.myitem1 = response.body.id;
+    })
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it('create a item with wrong values', function(done) {
+    request
+    .post('/v1/items')
+    .send({
+      name: 'myitem1',
+      type_id: 'testformyitemone'
+    })
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(400)
+    .expect('Content-Type', /json/)
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it('view a item', function(done) {
+    request
+    .get('/v1/items/'+global.myitem1)
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(200)
+    .expect('Content-Type', /json/)
+    .expect(function(response) {
+      assert(is.not.empty(response.body));
+      assert(is.equal('myitem1', response.body.name));
+    })
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it('view a item does not exists', function(done) {
+    request
+    .get('/v1/items/300000')
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(404)
+    .expect('Content-Type', /json/)
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it('update a item', function(done) {
+    request
+    .patch('/v1/items/'+global.myitem1)
+    .send({
+      name: 'test patch'
+    })
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(200)
+    .expect('Content-Type', /json/)
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it('update a item with error', function(done) {
+    request
+    .patch('/v1/items/'+global.myitem1)
+    .send({
+      name: true
+    })
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(400)
+    .expect('Content-Type', /json/)
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it('softdelete an item', function(done) {
+    request
+    .delete('/v1/items/'+global.myitem1)
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(200)
+    .expect('Content-Type', /json/)
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it('restore an item', function(done) {
+    request
+    .patch('/v1/items/'+global.myitem1)
+    .send({
+    })
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(200)
+    .expect('Content-Type', /json/)
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it('softdelete an item', function(done) {
+    request
+    .delete('/v1/items/'+global.myitem1)
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(200)
+    .expect('Content-Type', /json/)
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it('delete an item', function(done) {
+    request
+    .delete('/v1/items/'+global.myitem1)
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(200)
+    .expect('Content-Type', /json/)
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it('delete an item does not exists', function(done) {
+    request
+    .delete('/v1/items/30000000')
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(404)
+    .expect('Content-Type', /json/)
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it('verify audits added', function(done) {
+    request
+    .get('/v1/log/audits')
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(200)
+    .expect('Content-Type', /json/)
+    .expect(function(response) {
+      assert(is.not.empty(response.body));
+      assert(is.array(response.body));
+      assert(is.equal(10, response.body.length));
+
+      createItem = response.body[0];
+      assert(is.equal(200, createItem.httpcode));
+      assert(is.equal('CREATE', createItem.action));
+      assert(is.equal('', createItem.message));
+
+      failCreateItem = response.body[1];
+      assert(is.equal(400, failCreateItem.httpcode));
+      // assert(is.equal('CREATE', failCreateItem.action));
+      assert(is.equal('The Type id is not valid type, The Type id must be integer', failCreateItem.message));
+
+      viewNotexistsItem = response.body[2];
+      assert(is.equal(404, viewNotexistsItem.httpcode));
+      // assert(is.equal('VIEW', viewNotexistsItem.action));
+      assert(is.equal('This item has not be found', viewNotexistsItem.message));
+
+      updateItem = response.body[3];
+      assert(is.equal(200, updateItem.httpcode));
+      assert(is.equal('UPDATE', updateItem.action));
+      assert(is.equal('', updateItem.message));
+
+      failUpdateItem = response.body[4];
+      assert(is.equal(400, failUpdateItem.httpcode));
+      // assert(is.equal('UPDATE', failUpdateItem.action));
+      assert(is.equal('The Name is not valid type', failUpdateItem.message));
+
+      softdeleteItem = response.body[5];
+      assert(is.equal(200, softdeleteItem.httpcode));
+      assert(is.equal('SOFTDELETE', softdeleteItem.action));
+      assert(is.equal('', softdeleteItem.message));
+
+      restoreItem = response.body[6];
+      assert(is.equal(200, restoreItem.httpcode));
+      assert(is.equal('SOFTDELETE', restoreItem.action));
+      assert(is.equal('restore', restoreItem.message));
+
+      softdeleteItemBis = response.body[7];
+      assert(is.equal(200, softdeleteItemBis.httpcode));
+      assert(is.equal('SOFTDELETE', softdeleteItemBis.action));
+      assert(is.equal('', softdeleteItemBis.message));
+
+      deleteItem = response.body[8];
+      assert(is.equal(200, deleteItem.httpcode));
+      assert(is.equal('DELETE', deleteItem.action));
+      assert(is.equal('', deleteItem.message));
+
+      faildeleteItem = response.body[9];
+      assert(is.equal(404, faildeleteItem.httpcode));
+      // assert(is.equal('DELETE', faildeleteItem.action));
+      assert(is.equal('The item has not be found', faildeleteItem.message));
+
+    })
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+});

--- a/tests/RESTAPI/README.md
+++ b/tests/RESTAPI/README.md
@@ -6,6 +6,11 @@ Need run mountebank fake server (HTTP, SMTP):
 ./node_modules/.bin/mb --configfile mountebank/imposters.ejs
 ```
 
+Need run too php script to do actions on the database
+
+```
+php -S 127.0.0.1:8012 testDatabaseAccess.php
+```
 
 Then run the tests:
 

--- a/tests/RESTAPI/testDatabaseAccess.php
+++ b/tests/RESTAPI/testDatabaseAccess.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Capsule\Manager as Capsule;
+use Illuminate\Events\Dispatcher;
+use Illuminate\Container\Container;
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+$config = include(__DIR__ . '/../../src/config.php');
+
+$capsule = new Capsule();
+$capsule->addConnection($config['db']);
+$capsule->setEventDispatcher(new Dispatcher(new Container()));
+$capsule->setAsGlobal();
+$capsule->bootEloquent();
+
+preg_match('/\/truncate\/(\w+)/', $_SERVER['REQUEST_URI'], $matches, PREG_OFFSET_CAPTURE);
+
+if (count($matches) == 2)
+{
+  $capsule->table($matches[1][0])->truncate();
+}


### PR DESCRIPTION
Changes proposed in this pull request:

- put in audits table all modification of items, connections and all failed events

How to test the feature manually:

1. login and check in table `audits`
2. create an item and check in table `audits`
3.update an item and check in table `audits`

Pull request checklist:

- [x] code is manually tested
- [x] tests are updated
- [x] commit messages are relevant
- [x] documentation is updated (including code comments, commit messages…)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and precise `N/A` next to it._

Related to #
