### PR TITLE
Add an option to have item name unique in type configuration. closes …

### DIFF
--- a/db/migrations/20200720091613_types.php
+++ b/db/migrations/20200720091613_types.php
@@ -45,6 +45,7 @@ final class Types extends AbstractMigration
           ->addColumn('tree', 'boolean', ['default' => false])
           ->addColumn('allowtreemultipleroots', 'boolean', ['default' => false])
           ->addColumn('default_sub_organization', 'boolean', ['default' => false])
+          ->addColumn('unique_name', 'boolean', ['default' => false])
           ->addColumn('created_at', 'datetime')
           ->addColumn('updated_at', 'datetime', ['null' => true])
           ->addColumn('deleted_at', 'datetime', ['null' => true])

--- a/db/migrations/20220903062128_fusioninventory_data_model.php
+++ b/db/migrations/20220903062128_fusioninventory_data_model.php
@@ -291,7 +291,8 @@ final class FusioninventoryDataModel extends AbstractMigration
     // Create users
     $myType = $type->createType((object)[
       'name'         => 'Users',
-      'internalname' => 'users'
+      'internalname' => 'users',
+      'unique_name'  => true
     ], $token);
     $this->itemsId['users'] = $myType->id;
 

--- a/src/v1/Controllers/Config/Type.php
+++ b/src/v1/Controllers/Config/Type.php
@@ -44,6 +44,7 @@ final class Type
    *    in a tree.
    * @apiSuccess {Boolean}          types.allowtreemultipleroots        Set if the items of this type can
    *    have multiple roots.
+   * @apiSuccess {Boolean}          types.unique_name                   Set if the name of items is unique.
    * @apiSuccess {ISO8601}          types.created_at                    Date of the type creation.
    * @apiSuccess {null|ISO8601}     types.updated_at                    Date of the last type modification.
    * @apiSuccess {null|ISO8601}     types.deleted_at                    Date of the soft delete of the type.
@@ -189,6 +190,7 @@ final class Type
    *    in a tree.
    * @apiSuccess {Boolean}          allowtreemultipleroots        Set if the items of this type can
    *    have multiple roots.
+   * @apiSuccess {Boolean}          types.unique_name             Set if the name of items is unique.
    * @apiSuccess {ISO8601}          created_at                    Date of the type creation.
    * @apiSuccess {null|ISO8601}     updated_at                    Date of the last type modification.
    * @apiSuccess {null|ISO8601}     deleted_at                    Date of the soft delete of the type.
@@ -771,7 +773,8 @@ final class Type
       'allowtreemultipleroots' => 'type:boolean|boolean',
       'organization_id'        => 'type:integer|integer',
       'sub_organization'       => 'type:boolean|boolean',
-      'modeling'               => 'type:string'
+      'modeling'               => 'type:string',
+      'unique_name'            => 'type:boolean|boolean'
     ];
     \App\v1\Common::validateData($data, $dataFormat);
 
@@ -805,6 +808,10 @@ final class Type
     if (property_exists($data, 'modeling'))
     {
       $type->modeling = $data->modeling;
+    }
+    if (property_exists($data, 'unique_name'))
+    {
+      $type->unique_name = $data->unique_name;
     }
     $type->save();
 

--- a/src/v1/Models/Config/Type.php
+++ b/src/v1/Models/Config/Type.php
@@ -45,6 +45,7 @@ class Type extends Model
     'propertygroups',
     'tree',
     'allowtreemultipleroots',
+    'unique_name',
     'created_at',
     'updated_at',
     'deleted_at',
@@ -132,6 +133,11 @@ class Type extends Model
   public function getPropertygroupsAttribute()
   {
     return $this->propertygroups()->get();
+  }
+
+  public function getUniqueNameAttribute($value)
+  {
+    return boolval($value);
   }
 
 

--- a/src/v1/Models/Item.php
+++ b/src/v1/Models/Item.php
@@ -56,6 +56,7 @@ class Item extends Model
   protected $with = [
     // 'getItems'
   ];
+  protected $fillable = ['name', 'type_id'];
 
   public static function boot()
   {

--- a/tests/RESTAPI/01_type/0_type-GET.js
+++ b/tests/RESTAPI/01_type/0_type-GET.js
@@ -18,7 +18,7 @@ describe('type | Endpoint /v1/config/types', function() {
     .expect('Content-Type', /json/)
     .expect(function(response) {
       const laptopType = response.body[2]; // laptops
-      assert(is.propertyCount(laptopType, 16));
+      assert(is.propertyCount(laptopType, 17));
       assert(is.number(laptopType.id));
       assert(is.string(laptopType.name));
       assert(is.string(laptopType.internalname));

--- a/tests/RESTAPI/18_items_unique_name/with_unique_name.js
+++ b/tests/RESTAPI/18_items_unique_name/with_unique_name.js
@@ -1,0 +1,195 @@
+const supertest = require('supertest');
+const validator = require('validator');
+const assert = require('assert');
+const is = require('is_js');
+const { faker } = require('@faker-js/faker');
+
+const request = supertest('http://127.0.0.1/fusionsuite/backend');
+
+/**
+* /v1/types endpoint
+*/
+describe('items_unique_name | tests with type have unique_name enabled', function() {
+
+  it('create a new type with unique name', function(done) {
+    request
+    .post('/v1/config/types')
+    .send({name: 'type with unique name','unique_name': true})
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(200)
+    .expect('Content-Type', /json/)
+    .expect(function(response) {
+      assert(is.propertyCount(response.body, 1));
+
+      assert(is.integer(response.body.id));
+      assert(validator.matches('' + response.body.id, /^\d+$/));
+      global.id = response.body.id;
+    })
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it('create a new item', function(done) {
+    request
+    .post('/v1/items')
+    .send({name: 'myunique name',type_id: global.id,properties:[]})
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(200)
+    .expect('Content-Type', /json/)
+    .expect(function(response) {
+      assert(is.propertyCount(response.body, 2));
+      assert(is.integer(response.body.id));
+      assert(is.integer(response.body.id_bytype));
+      assert(validator.matches('' + response.body.id, /^\d+$/));
+    })
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it('create a new item with same name => error', function(done) {
+    request
+    .post('/v1/items')
+    .send({name: 'myunique name',type_id: global.id,properties:[]})
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(400)
+    .expect('Content-Type', /json/)
+    .expect(function(response) {
+      assert(is.propertyCount(response.body, 2));
+      assert(validator.equals(response.body.status, 'error'));
+      assert(validator.equals(response.body.message, 'The name must be unique and another item has yet this name'));
+    })
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it('create a new item with same name but with space at the beginning => error', function(done) {
+    request
+    .post('/v1/items')
+    .send({name: ' myunique name',type_id: global.id,properties:[]})
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(400)
+    .expect('Content-Type', /json/)
+    .expect(function(response) {
+      assert(is.propertyCount(response.body, 2));
+      assert(validator.equals(response.body.status, 'error'));
+      assert(validator.equals(response.body.message, 'The name must be unique and another item has yet this name'));
+    })
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it('create a second new item', function(done) {
+    request
+    .post('/v1/items')
+    .send({name: 'myunique name bis',type_id: global.id,properties:[]})
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(200)
+    .expect('Content-Type', /json/)
+    .expect(function(response) {
+      assert(is.propertyCount(response.body, 2));
+      assert(is.integer(response.body.id));
+      assert(is.integer(response.body.id_bytype));
+      assert(validator.matches('' + response.body.id, /^\d+$/));
+      global.idBis = response.body.id;
+    })
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it('update the item name with same name than the first item => error', function(done) {
+    request
+    .patch('/v1/items/' + global.idBis)
+    .send({name: 'myunique name'})
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(400)
+    .expect('Content-Type', /json/)
+    .expect(function(response) {
+      assert(is.propertyCount(response.body, 2));
+      assert(validator.equals(response.body.status, 'error'));
+      assert(validator.equals(response.body.message, 'The name must be unique and another item has yet this name'));
+    })
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it('update the item name with same name than the first item but with space at the beginning => error', function(done) {
+    request
+    .patch('/v1/items/' + global.idBis)
+    .send({name: ' myunique name'})
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(400)
+    .expect('Content-Type', /json/)
+    .expect(function(response) {
+      assert(is.propertyCount(response.body, 2));
+      assert(validator.equals(response.body.status, 'error'));
+      assert(validator.equals(response.body.message, 'The name must be unique and another item has yet this name'));
+    })
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it('soft delete the type', function(done) {
+    request
+    .delete('/v1/config/types/' + global.id)
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect('Content-Type', /json/)
+    .expect(200)
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it('permanently delete the type', function(done) {
+    request
+    .delete('/v1/config/types/' + global.id)
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect('Content-Type', /json/)
+    .expect(200)
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+});

--- a/tests/RESTAPI/18_items_unique_name/without_unique_name.js
+++ b/tests/RESTAPI/18_items_unique_name/without_unique_name.js
@@ -1,0 +1,187 @@
+const supertest = require('supertest');
+const validator = require('validator');
+const assert = require('assert');
+const is = require('is_js');
+const { faker } = require('@faker-js/faker');
+
+const request = supertest('http://127.0.0.1/fusionsuite/backend');
+
+/**
+* /v1/types endpoint
+*/
+describe('items_unique_name | tests with type have unique_name disabled', function() {
+
+  it('create a new type', function(done) {
+    request
+    .post('/v1/config/types')
+    .send({name: 'type with name'})
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(200)
+    .expect('Content-Type', /json/)
+    .expect(function(response) {
+      assert(is.propertyCount(response.body, 1));
+
+      assert(is.integer(response.body.id));
+      assert(validator.matches('' + response.body.id, /^\d+$/));
+      global.id = response.body.id;
+    })
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it('create a new item', function(done) {
+    request
+    .post('/v1/items')
+    .send({name: 'myunique name',type_id: global.id,properties:[]})
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(200)
+    .expect('Content-Type', /json/)
+    .expect(function(response) {
+      assert(is.propertyCount(response.body, 2));
+      assert(is.integer(response.body.id));
+      assert(is.integer(response.body.id_bytype));
+      assert(validator.matches('' + response.body.id, /^\d+$/));
+    })
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it('create a new item with same name', function(done) {
+    request
+    .post('/v1/items')
+    .send({name: 'myunique name',type_id: global.id,properties:[]})
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(200)
+    .expect('Content-Type', /json/)
+    .expect(function(response) {
+      assert(is.propertyCount(response.body, 2));
+      assert(is.integer(response.body.id));
+      assert(is.integer(response.body.id_bytype));
+      assert(validator.matches('' + response.body.id, /^\d+$/));
+    })
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it('create a new item with same name but with space at the beginning', function(done) {
+    request
+    .post('/v1/items')
+    .send({name: ' myunique name',type_id: global.id,properties:[]})
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(200)
+    .expect('Content-Type', /json/)
+    .expect(function(response) {
+      assert(is.propertyCount(response.body, 2));
+      assert(is.integer(response.body.id));
+      assert(is.integer(response.body.id_bytype));
+      assert(validator.matches('' + response.body.id, /^\d+$/));
+    })
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it('create a second new item', function(done) {
+    request
+    .post('/v1/items')
+    .send({name: 'myunique name bis',type_id: global.id,properties:[]})
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(200)
+    .expect('Content-Type', /json/)
+    .expect(function(response) {
+      assert(is.propertyCount(response.body, 2));
+      assert(is.integer(response.body.id));
+      assert(is.integer(response.body.id_bytype));
+      assert(validator.matches('' + response.body.id, /^\d+$/));
+      global.idBis = response.body.id;
+    })
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it('update the item name with same name than the first item', function(done) {
+    request
+    .patch('/v1/items/' + global.idBis)
+    .send({name: 'myunique name'})
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(200)
+    .expect('Content-Type', /json/)
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it('update the item name with same name than the first item but with space at the beginning', function(done) {
+    request
+    .patch('/v1/items/' + global.idBis)
+    .send({name: ' myunique name'})
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(200)
+    .expect('Content-Type', /json/)
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it('soft delete the type', function(done) {
+    request
+    .delete('/v1/config/types/' + global.id)
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect('Content-Type', /json/)
+    .expect(200)
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it('permanently delete the type', function(done) {
+    request
+    .delete('/v1/config/types/' + global.id)
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect('Content-Type', /json/)
+    .expect(200)
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+});


### PR DESCRIPTION
…fusionSuite/FusionSuite#46

Changes proposed in this pull request:

- put an option in type configuration to have unique name for items
- check on create item and when update item
-

How to test the feature manually:

1. create type with unique_name 
2. create an item with a name
3. create an other item with same name and will have an error

Pull request checklist:

- [x] code is manually tested
- [x] tests are updated
- [x] commit messages are relevant
- [x] documentation is updated (including code comments, commit messages…)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and precise `N/A` next to it._

Related to #
