### PR TITLE
Modify route for refreshtoken

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -68,7 +68,13 @@ $configSecret = include(__DIR__ . '/../config/current/config.php');
 $secret = $configSecret['jwtsecret'];
 
 $app->add(new Tuupola\Middleware\JwtAuthentication([
-  "ignore" => [$prefix . "/v1/token", $prefix . "/ping", $prefix . "/v1/fusioninventory", $prefix . "/v1/status"],
+  "ignore" => [
+    $prefix . "/v1/token",
+    $prefix . "/v1/refreshtoken",
+    $prefix . "/ping",
+    $prefix . "/v1/fusioninventory",
+    $prefix . "/v1/status"
+  ],
   "secure" => false,
   "secret" => $secret,
   // "callback" => function ($request, $response, $arguments) use ($container) { ???
@@ -121,7 +127,17 @@ $customErrorHandler = function (
   }
   elseif ($exception->getCode() > 0)
   {
-    if (strstr($request->getUri()->getPath(), 'token'))
+    if (strstr($request->getUri()->getPath(), 'refreshtoken'))
+    {
+      \App\v1\Controllers\Log\Audit::addEntry(
+        $request,
+        'CONNECTION',
+        'fail on refreshtoken',
+        'User',
+        null,
+        $exception->getCode()
+      );
+    } elseif (strstr($request->getUri()->getPath(), 'token'))
     {
       $data = json_decode($request->getBody());
       \App\v1\Controllers\Log\Audit::addEntry(

--- a/src/Route.php
+++ b/src/Route.php
@@ -38,6 +38,7 @@ final class Route
     $app->group($prefix . '/v1', function (RouteCollectorProxy $v1)
     {
       $v1->post("/token", \App\v1\Controllers\Token::class . ':postToken');
+      $v1->post("/refreshtoken", \App\v1\Controllers\Token::class . ':postRefreshToken');
       $v1->get("/status", \App\v1\Controllers\Status::class . ':getStatus');
 
       $v1->group('/fusioninventory', function (RouteCollectorProxy $fusion)

--- a/tests/RESTAPI/19_refreshToken/01_create-users-POST.js
+++ b/tests/RESTAPI/19_refreshToken/01_create-users-POST.js
@@ -1,0 +1,73 @@
+const supertest = require('supertest');
+const validator = require('validator');
+const assert = require('assert');
+const is = require('is_js');
+const { faker } = require('@faker-js/faker');
+
+const request = supertest('http://127.0.0.1/fusionsuite/backend');
+
+/**
+* /v1/types endpoint
+*/
+describe('refresh token | create users', function() {
+
+  it ('create a user', function(done) {
+    request
+    .post('/v1/items')
+    .send({
+      name: 'user1',
+      type_id: 2,
+    })
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(200)
+    .expect('Content-Type', /json/)
+    .expect(function(response) {
+      assert(is.propertyCount(response.body, 2));
+      assert(is.integer(response.body.id));
+      assert(is.integer(response.body.id_bytype));
+      assert(validator.matches('' + response.body.id, /^\d+$/));
+      global.user1 = response.body.id;
+    })
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it ('check if the user is created', function(done) {
+    request
+    .get('/v1/items/'+global.user1)
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(200)
+    .expect('Content-Type', /json/)
+    .expect(function(response) {
+      assert(is.not.empty(response.body));
+      assert(is.equal('user1', response.body.name));
+    })
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it('attach user1 to the admin role', function(done) {
+    request
+    .post('/v1/config/roles/1/user/'+global.user1)
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(200)
+    .expect('Content-Type', /json/)
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+});

--- a/tests/RESTAPI/19_refreshToken/02_token-users.js
+++ b/tests/RESTAPI/19_refreshToken/02_token-users.js
@@ -1,0 +1,232 @@
+const supertest = require('supertest');
+const validator = require('validator');
+const assert = require('assert');
+const is = require('is_js');
+const { faker } = require('@faker-js/faker');
+
+const request = supertest('http://127.0.0.1/fusionsuite/backend');
+
+/**
+* /v1/types endpoint
+*/
+describe('refresh token | usage of the refreshtoken', function() {
+
+  it ('get the token for user user1', function(done) {
+    request
+    .post('/v1/token')
+    .send({login: 'user1', password: 'test'})
+    .set('Accept', 'application/json')
+    .expect(200)
+    .expect('Content-Type', /json/)
+    .expect(function(response) {
+      assert(is.propertyCount(response.body, 3));
+
+      assert(validator.isJWT(response.body.token));
+      assert(validator.matches(response.body.refreshtoken, /^\w+$/));
+
+      assert(is.integer(response.body.expires));
+      assert(validator.matches('' + response.body.expires, /^\d{10}$/));
+      global.tokenUser1 = response.body.token;
+      global.refreshTokenUser1 = response.body.refreshtoken;
+    })
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it ('wait 1 second to be sure timestamp changed', function(done) {
+    setTimeout (function() {
+      return done();
+    }, 1000);
+  });
+
+  it ('try login with refresh token and no jwt', function(done) {
+    request
+    .post('/v1/refreshtoken')
+    .send({
+      refreshtoken: global.refreshTokenUser1,
+    })
+    .set('Accept', 'application/json')
+    .expect(400)
+    .expect('Content-Type', /json/)
+    .expect(function(response) {
+      assert(is.propertyCount(response.body, 2));
+      assert(validator.equals(response.body.status, 'error'));
+      assert(validator.equals(response.body.message, 'The Token is required'));
+    })
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it ('try login with no refresh token and jwt', function(done) {
+    request
+    .post('/v1/refreshtoken')
+    .send({
+     token: global.tokenUser1,
+    })
+    .set('Accept', 'application/json')
+    .expect(400)
+    .expect('Content-Type', /json/)
+    .expect(function(response) {
+      assert(is.propertyCount(response.body, 2));
+      assert(validator.equals(response.body.status, 'error'));
+      assert(validator.equals(response.body.message, 'The Refreshtoken is required'));
+    })
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it ('try login with no refresh token and no jwt', function(done) {
+    request
+    .post('/v1/refreshtoken')
+    .send({})
+    .set('Accept', 'application/json')
+    .expect(400)
+    .expect('Content-Type', /json/)
+    .expect(function(response) {
+      assert(is.propertyCount(response.body, 2));
+      assert(validator.equals(response.body.status, 'error'));
+      assert(validator.equals(response.body.message, 'The Token is required, The Refreshtoken is required'));
+    })
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it ('try login with wrong type of refresh token and jwt', function(done) {
+    request
+    .post('/v1/refreshtoken')
+    .send({
+      token: true,
+      refreshtoken: global.refreshTokenUser1,
+    })
+    .set('Accept', 'application/json')
+    .expect(400)
+    .expect('Content-Type', /json/)
+    .expect(function(response) {
+      assert(is.propertyCount(response.body, 2));
+      assert(validator.equals(response.body.status, 'error'));
+      assert(validator.equals(response.body.message, 'The Token is not valid type'));
+    })
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it ('try login with refresh token and JWT malformed', function(done) {
+    request
+    .post('/v1/refreshtoken')
+    .send({
+      token: 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE2NjcwMzxNjQsImV4cCI6MTY2NzAzMDE5NCwianRpIjoiIiwic3ViIjoiIiwic2NvcGUiOltdLCJ1c2VyX2lkIjoyLCJyb2xlX2lkIjoxLCJmaXJzdG5hbWUiOiJTdGV2ZSIsImxhc3RuYW1lIjoiUm9nZXJzIiwiYXBpdmVyc2lvbiI6InYxIiwib3JnYW5pemF0aW9uX2lkIjoxLCJzdWJfb3JnYW5pemF0aW9uIjp0cnVlfQ.PGyKarzzi2_O4xGXF_GC8DFqj8AlGjD_R8yAl3UnjIw',
+      refreshtoken: global.refreshTokenUser1,
+    })
+    .set('Accept', 'application/json')
+    .expect(500)
+    .expect('Content-Type', /json/)
+    .expect(function(response) {
+      assert(is.propertyCount(response.body, 2));
+      assert(validator.equals(response.body.status, 'error'));
+      assert(validator.equals(response.body.message, 'Syntax error, malformed JSON'));
+    })
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it ('try login with refresh token and JWT have wrong signature', function(done) {
+    request
+    .post('/v1/refreshtoken')
+    .send({
+      token: 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE2NjcwMzEwMTksImV4cCI6MTY2NzAzMTA0OSwianRpIjoiIiwic3ViIjoiIiwic2NvcGUiOltdLCJ1c2VyX2lkIjo1LCJyb2xlX2lkIjoxLCJmaXJzdG5hbWUiOiJ5byIsImxhc3RuYW1lIjoibG8iLCJhcGl2ZXJzaW9uIjoidjEiLCJvcmdhbml6YXRpb25faWQiOjEsInN1Yl9vcmdhbml6YXRpb24iOnRydWV9.fsLmNtavIAuYHgAxziaMCMDhoxD0DP0mpSoNitJ2ihM',
+      refreshtoken: global.refreshTokenUser1,
+    })
+    .set('Accept', 'application/json')
+    .expect(500)
+    .expect('Content-Type', /json/)
+    .expect(function(response) {
+      assert(is.propertyCount(response.body, 2));
+      assert(validator.equals(response.body.status, 'error'));
+      assert(validator.equals(response.body.message, 'Signature verification failed'));
+    })
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it ('try login with wrong refresh token and right JWT', function(done) {
+    request
+    .post('/v1/refreshtoken')
+    .send({
+      token: global.tokenUser1,
+      refreshtoken: 'xxxxx',
+    })
+    .set('Accept', 'application/json')
+    .expect(401)
+    .expect('Content-Type', /json/)
+    .expect(function(response) {
+      assert(is.propertyCount(response.body, 2));
+      assert(validator.equals(response.body.status, 'error'));
+      assert(validator.equals(response.body.message, 'Error when authentication, refreshtoken not right'));
+    })
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it ('try login with right refresh token and right JWT', function(done) {
+    request
+    .post('/v1/refreshtoken')
+    .send({
+      token: global.tokenUser1,
+      refreshtoken: global.refreshTokenUser1,
+    })
+    .set('Accept', 'application/json')
+    .expect(200)
+    .expect('Content-Type', /json/)
+    .expect(function(response) {
+      assert(is.propertyCount(response.body, 3));
+
+      assert(validator.isJWT(response.body.token));
+      assert(validator.matches(response.body.refreshtoken, /^\w+$/));
+
+      assert(is.integer(response.body.expires));
+      assert(validator.matches('' + response.body.expires, /^\d{10}$/));
+      assert(is.not.equal(response.body.token, global.tokenUser1));
+      global.tokenUser1 = response.body.token;
+      global.refreshTokenUser1 = response.body.refreshtoken;
+    })
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+});

--- a/tests/RESTAPI/19_refreshToken/05_delete-users.js
+++ b/tests/RESTAPI/19_refreshToken/05_delete-users.js
@@ -1,0 +1,39 @@
+const supertest = require('supertest');
+const validator = require('validator');
+const assert = require('assert');
+const is = require('is_js');
+const { faker } = require('@faker-js/faker');
+
+const request = supertest('http://127.0.0.1/fusionsuite/backend');
+
+describe('organizations | items | delete users', function() {
+
+  it('Soft delete the user1', function(done) {
+    request
+    .delete('/v1/items/' + global.user1.toString())
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect('Content-Type', /json/)
+    .expect(200)
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+  it('Hard delete the user1', function(done) {
+    request
+    .delete('/v1/items/' + global.user1.toString())
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect('Content-Type', /json/)
+    .expect(200)
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+});


### PR DESCRIPTION
Changes proposed in this pull request:

- add new route for the refreshtoken
- add tests

How to test the feature manually:

1. login with `/v1/token`
2. refresh the token with the token and the refreshtoken on `/v1/refreshtoken`

Pull request checklist:

- [x] code is manually tested
- [x] tests are updated
- [x] commit messages are relevant
- [x] documentation is updated (including code comments, commit messages…)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and precise `N/A` next to it._

Related to #
