### PR TITLE
Fix php error when login with wrong username

### DIFF
--- a/src/v1/Controllers/Token.php
+++ b/src/v1/Controllers/Token.php
@@ -78,7 +78,7 @@ final class Token
   public function postToken(Request $request, Response $response, $args): Response
   {
     $data = json_decode($request->getBody());
-
+    $GLOBALS['user_id'] = null;
     if (
         \App\v1\Post::postHasProperties($data, ['login']) === true
         && \App\v1\Post::postHasProperties($data, ['password']) === true

--- a/tests/RESTAPI/20_getToken/01_create-users-POST.js
+++ b/tests/RESTAPI/20_getToken/01_create-users-POST.js
@@ -1,0 +1,73 @@
+const supertest = require('supertest');
+const validator = require('validator');
+const assert = require('assert');
+const is = require('is_js');
+const { faker } = require('@faker-js/faker');
+
+const request = supertest('http://127.0.0.1/fusionsuite/backend');
+
+/**
+* /v1/types endpoint
+*/
+describe('refresh token | create users', function() {
+
+  it ('create a user', function(done) {
+    request
+    .post('/v1/items')
+    .send({
+      name: 'user1',
+      type_id: 2,
+    })
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(200)
+    .expect('Content-Type', /json/)
+    .expect(function(response) {
+      assert(is.propertyCount(response.body, 2));
+      assert(is.integer(response.body.id));
+      assert(is.integer(response.body.id_bytype));
+      assert(validator.matches('' + response.body.id, /^\d+$/));
+      global.user1 = response.body.id;
+    })
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it ('check if the user is created', function(done) {
+    request
+    .get('/v1/items/'+global.user1)
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(200)
+    .expect('Content-Type', /json/)
+    .expect(function(response) {
+      assert(is.not.empty(response.body));
+      assert(is.equal('user1', response.body.name));
+    })
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it('attach user1 to the admin role', function(done) {
+    request
+    .post('/v1/config/roles/1/user/'+global.user1)
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(200)
+    .expect('Content-Type', /json/)
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+});

--- a/tests/RESTAPI/20_getToken/02_token-users.js
+++ b/tests/RESTAPI/20_getToken/02_token-users.js
@@ -1,0 +1,61 @@
+const supertest = require('supertest');
+const validator = require('validator');
+const assert = require('assert');
+const is = require('is_js');
+const { faker } = require('@faker-js/faker');
+
+const request = supertest('http://127.0.0.1/fusionsuite/backend');
+
+/**
+* /v1/types endpoint
+*/
+describe('get token | usage of the refreshtoken', function() {
+
+  it ('get the token for user user1', function(done) {
+    request
+    .post('/v1/token')
+    .send({login: 'user1', password: 'test'})
+    .set('Accept', 'application/json')
+    .expect(200)
+    .expect('Content-Type', /json/)
+    .expect(function(response) {
+      assert(is.propertyCount(response.body, 3));
+
+      assert(validator.isJWT(response.body.token));
+      assert(validator.matches(response.body.refreshtoken, /^\w+$/));
+
+      assert(is.integer(response.body.expires));
+      assert(validator.matches('' + response.body.expires, /^\d{10}$/));
+      global.tokenUser1 = response.body.token;
+      global.refreshTokenUser1 = response.body.refreshtoken;
+    })
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+
+  it ('try login but with bad username', function(done) {
+    request
+    .post('/v1/token')
+    .send({login: 'unknown user', password: 'test'})
+    .set('Accept', 'application/json')
+    .expect(401)
+    .expect('Content-Type', /json/)
+    .expect(function(response) {
+      assert(is.propertyCount(response.body, 2));
+      assert(validator.equals(response.body.status, 'error'));
+      assert(validator.equals(response.body.message, 'Error when authentication, login or password not right'));
+    })
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+});

--- a/tests/RESTAPI/20_getToken/05_delete-users.js
+++ b/tests/RESTAPI/20_getToken/05_delete-users.js
@@ -6,7 +6,7 @@ const { faker } = require('@faker-js/faker');
 
 const request = supertest('http://127.0.0.1/fusionsuite/backend');
 
-describe('refresh token | delete users', function() {
+describe('get token | delete users', function() {
 
   it('Soft delete the user1', function(done) {
     request


### PR DESCRIPTION
Changes proposed in this pull request:

- fix php error when try to connect with wrong username

How to test the feature manually:

1. connect to `/v1/token` with wrong login
2. must have error message, but not php error

Pull request checklist:

- [x] code is manually tested
- [x] tests are updated
- [x] commit messages are relevant
- [x] documentation is updated (including code comments, commit messages…)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and precise `N/A` next to it._

Related to #
