### PR TITLE
Fix CORS headers for exceptions response

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -115,13 +115,26 @@ $customErrorHandler = function (
   bool $logErrorDetails
 ) use ($app)
 {
+  $response = $app->getResponseFactory()->createResponse();
+  // Set headers for CORS if required
+  $headers = $request->getHeaders();
+  if (isset($headers['Origin']))
+  {
+    $response = $response->withHeader('Access-Control-Allow-Origin', $headers['Origin']);
+    $response = $response->withHeader(
+      'Access-Control-Allow-Headers',
+      'Origin,Content-Type,Accept,Authorization,Cache-Control,Pragma,Expires'
+    );
+    $response = $response->withHeader('Access-Control-Allow-Credentials', 'true');
+    $response = $response->withHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS, PUT, DELETE');
+  }
+
   if ($exception->getCode() == 23000 || $exception->getCode() == 23505)
   {
     $error = [
       "status"  => "error",
       "message" => "The element already exists"
     ];
-    $response = $app->getResponseFactory()->createResponse();
     $response->getBody()->write(json_encode($error));
     return $response->withStatus(409)->withHeader('Content-Type', 'application/json');
   }
@@ -163,7 +176,6 @@ $customErrorHandler = function (
       "status"  => "error",
       "message" => $exception->getMessage()
     ];
-    $response = $app->getResponseFactory()->createResponse();
     $response->getBody()->write(json_encode($error));
     return $response->withStatus($exception->getCode())->withHeader('Content-Type', 'application/json');
   }
@@ -172,7 +184,6 @@ $customErrorHandler = function (
     "status"  => "error",
     "message" => $exception->getMessage()
   ];
-  $response = $app->getResponseFactory()->createResponse();
   $response->getBody()->write(json_encode($error));
   return $response->withStatus(500)->withHeader('Content-Type', 'application/json');
 };


### PR DESCRIPTION
Changes proposed in this pull request:

- Add missing CORS headers on response in case of exceptions

How to test the feature manually:

1. test with frontend + CORS configured in the webserver (nginx for exemple)

Pull request checklist:

- [X] code is manually tested
- [ ] tests are updated
- [X] commit messages are relevant
- [X] documentation is updated (including code comments, commit messages…)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and precise `N/A` next to it._

Related to #
