### PR TITLE
Fix add / delete property on type when have yet items created. closes…

### DIFF
--- a/src/v1/Controllers/Config/Type.php
+++ b/src/v1/Controllers/Config/Type.php
@@ -578,6 +578,13 @@ final class Type
     // use touch() to update updated_at in the type
     $type->touch();
 
+    // add this property to all items yet created for this type
+    $items = \App\v1\Models\Item::where('type_id', $args['id'])->get();
+    foreach ($items as $item)
+    {
+      \App\v1\Controllers\Item::attachPropertyDefaultToItem($property, $item);
+    }
+
     $response->getBody()->write(json_encode([]));
     return $response->withHeader('Content-Type', 'application/json');
   }
@@ -638,6 +645,13 @@ final class Type
     $type->properties()->detach($args['propertyid']);
     // use touch() to update updated_at in the type
     $type->touch();
+
+    // delete the property to all items have this property
+    $items = \App\v1\Models\Item::where('type_id', $args['id'])->get();
+    foreach ($items as $item)
+    {
+      $item->properties()->detach($args['propertyid']);
+    }
 
     $response->getBody()->write(json_encode([]));
     return $response->withHeader('Content-Type', 'application/json');
@@ -922,6 +936,13 @@ final class Type
           if (!in_array($propId, $propertiesId))
           {
             $typeItem->properties()->attach($propId);
+            // add this property to all items yet created for this type
+            $items = \App\v1\Models\Item::where('type_id', $typeId)->get();
+            $property = \App\v1\Models\Config\Property::find($propId);
+            foreach ($items as $item)
+            {
+              \App\v1\Controllers\Item::attachPropertyDefaultToItem($property, $item);
+            }
           }
         }
 

--- a/src/v1/Controllers/Item.php
+++ b/src/v1/Controllers/Item.php
@@ -1353,34 +1353,7 @@ final class Item
       {
         continue;
       }
-      $fieldName = 'value_' . $prop->valuetype;
-      if ($prop->valuetype == 'itemlinks')
-      {
-        // TODO
-      }
-      elseif ($prop->valuetype == 'typelinks' && !is_null($prop->default))
-      {
-        foreach ($prop->default as $typelink)
-        {
-          $item->properties()->attach($prop->id, ['value_typelink' => $typelink]);
-        }
-      }
-      elseif ($prop->valuetype == 'date' && $prop->default == '' && !is_null($prop->default))
-      {
-        $item->properties()->attach($prop->id, [$fieldName => date('Y-m-d')]);
-      }
-      elseif ($prop->valuetype == 'datetime' && $prop->default == '' && !is_null($prop->default))
-      {
-        $item->properties()->attach($prop->id, [$fieldName => date('Y-m-d H:i:s')]);
-      }
-      elseif ($prop->valuetype == 'time' && $prop->default == '' && !is_null($prop->default))
-      {
-        $item->properties()->attach($prop->id, [$fieldName => date('H:i:s')]);
-      }
-      else
-      {
-        $item->properties()->attach($prop->id, [$fieldName => $prop->default]);
-      }
+      $this->attachPropertyDefaultToItem($prop, $item);
     }
 
     // run rules
@@ -1388,6 +1361,40 @@ final class Item
     return $item;
   }
 
+  /**
+   * Attach a property with default value to an item
+   */
+  public static function attachPropertyDefaultToItem($property, $item)
+  {
+    $fieldName = 'value_' . $property->valuetype;
+    if ($property->valuetype == 'itemlinks')
+    {
+      // TODO
+    }
+    elseif ($property->valuetype == 'typelinks' && !is_null($property->default))
+    {
+      foreach ($property->default as $typelink)
+      {
+        $item->properties()->attach($property->id, ['value_typelink' => $typelink]);
+      }
+    }
+    elseif ($property->valuetype == 'date' && $property->default == '' && !is_null($property->default))
+    {
+      $item->properties()->attach($property->id, [$fieldName => date('Y-m-d')]);
+    }
+    elseif ($property->valuetype == 'datetime' && $property->default == '' && !is_null($property->default))
+    {
+      $item->properties()->attach($property->id, [$fieldName => date('Y-m-d H:i:s')]);
+    }
+    elseif ($property->valuetype == 'time' && $property->default == '' && !is_null($property->default))
+    {
+      $item->properties()->attach($property->id, [$fieldName => date('H:i:s')]);
+    }
+    else
+    {
+      $item->properties()->attach($property->id, [$fieldName => $property->default]);
+    }
+  }
 
   private function checkProperty($id, $valuetype = null)
   {

--- a/tests/RESTAPI/21_itemPropertyWhenAddDeletePropertyToType/1_createType.js
+++ b/tests/RESTAPI/21_itemPropertyWhenAddDeletePropertyToType/1_createType.js
@@ -1,0 +1,50 @@
+const supertest = require('supertest');
+const validator = require('validator');
+const assert = require('assert');
+const is = require('is_js');
+const { faker } = require('@faker-js/faker');
+
+const request = supertest('http://127.0.0.1/fusionsuite/backend');
+
+describe('itemPropertyWhenAddPropertyToType | create type', function() {
+  it('create a new type', function(done) {
+    request
+    .post('/v1/config/types')
+    .send({
+      name: 'testType',
+    })
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(200)
+    .expect('Content-Type', /json/)
+    .expect(function(response) {
+      assert(is.propertyCount(response.body, 1));
+      assert(is.integer(response.body.id));
+      assert(validator.matches('' + response.body.id, /^\d+$/));
+      global.typeId = response.body.id;
+    })
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it('Attach a property to the type', function(done) {
+    request
+    .post('/v1/config/types/' + global.typeId.toString() + '/property/6')
+    .send()
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(200)
+    .expect('Content-Type', /json/)
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+});

--- a/tests/RESTAPI/21_itemPropertyWhenAddDeletePropertyToType/2_createItem.js
+++ b/tests/RESTAPI/21_itemPropertyWhenAddDeletePropertyToType/2_createItem.js
@@ -1,0 +1,36 @@
+const supertest = require('supertest');
+const validator = require('validator');
+const assert = require('assert');
+const is = require('is_js');
+const { faker } = require('@faker-js/faker');
+
+const request = supertest('http://127.0.0.1/fusionsuite/backend');
+
+describe('itemPropertyWhenAddPropertyToType | create item', function() {
+  it('create an item', function(done) {
+    request
+    .post('/v1/items')
+    .send({
+      name: 'an item of the type',
+      type_id: global.typeId,
+    })
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(200)
+    .expect('Content-Type', /json/)
+    .expect(function(response) {
+      assert(is.propertyCount(response.body, 2));
+      assert(is.integer(response.body.id));
+      assert(is.integer(response.body.id_bytype));
+      assert(validator.matches('' + response.body.id, /^\d+$/));
+      assert(is.equal(1, response.body.id_bytype));
+      global.itemId = response.body.id;
+    })
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+});

--- a/tests/RESTAPI/21_itemPropertyWhenAddDeletePropertyToType/3_addNewPropertyToType.js
+++ b/tests/RESTAPI/21_itemPropertyWhenAddDeletePropertyToType/3_addNewPropertyToType.js
@@ -1,0 +1,46 @@
+const supertest = require('supertest');
+const validator = require('validator');
+const assert = require('assert');
+const is = require('is_js');
+const { faker } = require('@faker-js/faker');
+
+const request = supertest('http://127.0.0.1/fusionsuite/backend');
+
+describe('itemPropertyWhenAddPropertyToType | add new property to type', function() {
+  it('Attach a property to the type', function(done) {
+    request
+    .post('/v1/config/types/' + global.typeId.toString() + '/property/7')
+    .send()
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(200)
+    .expect('Content-Type', /json/)
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it('verify the item have right the property 7', function(done) {
+    request
+    .get('/v1/items/'+global.itemId)
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(200)
+    .expect('Content-Type', /json/)
+    .expect(function(response) {
+      assert(is.not.empty(response.body), 'The body must contain something');
+      assert(is.object(response.body), 'the body response must be an object');
+      assert(is.equal(2, response.body.properties.length), 'must have 2 properties');
+      assert(is.equal(7, response.body.properties[1].id), 'the second property id must be 7');
+    })
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+});

--- a/tests/RESTAPI/21_itemPropertyWhenAddDeletePropertyToType/4_deletePropertyToType.js
+++ b/tests/RESTAPI/21_itemPropertyWhenAddDeletePropertyToType/4_deletePropertyToType.js
@@ -1,0 +1,46 @@
+const supertest = require('supertest');
+const validator = require('validator');
+const assert = require('assert');
+const is = require('is_js');
+const { faker } = require('@faker-js/faker');
+
+const request = supertest('http://127.0.0.1/fusionsuite/backend');
+
+describe('itemPropertyWhenAddPropertyToType | delete property to type', function() {
+  it('Attach a property to the type', function(done) {
+    request
+    .delete('/v1/config/types/' + global.typeId.toString() + '/property/7')
+    .send()
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(200)
+    .expect('Content-Type', /json/)
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it('verify the item not have right the property 7', function(done) {
+    request
+    .get('/v1/items/'+global.itemId)
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(200)
+    .expect('Content-Type', /json/)
+    .expect(function(response) {
+      assert(is.not.empty(response.body), 'The body must contain something');
+      assert(is.object(response.body), 'the body response must be an object');
+      assert(is.equal(1, response.body.properties.length), 'must have 1 property');
+      assert(is.equal(6, response.body.properties[0].id), 'the id of the unique property must be 6');
+    })
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+});

--- a/tests/RESTAPI/21_itemPropertyWhenAddDeletePropertyToType/5_addNewPropertyToTypeByTemplate.js
+++ b/tests/RESTAPI/21_itemPropertyWhenAddDeletePropertyToType/5_addNewPropertyToTypeByTemplate.js
@@ -1,0 +1,71 @@
+const supertest = require('supertest');
+const validator = require('validator');
+const assert = require('assert');
+const is = require('is_js');
+const { faker } = require('@faker-js/faker');
+
+const request = supertest('http://127.0.0.1/fusionsuite/backend');
+
+describe('itemPropertyWhenAddPropertyToTypeByTemplate | add new property to type', function() {
+  it('Attach a property to the type', function(done) {
+    request
+    .post('/v1/config/types/templates')
+    .send({
+      license:[],
+      types: [
+        {
+          name: 'testType',
+          internalname: "testtype",
+          propertygroups: [
+            {
+              name: "Main",
+              properties: [
+                {
+                  name: 'Installation date',
+                  internalname: 'installationdate',
+                  valuetype: 'date',
+                  regexformat: '',
+                  listvalues: [],
+                  unit: '',
+                  default: null,
+                  description: ''
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    })
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(200)
+    .expect('Content-Type', /json/)
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+
+  it('verify the item have right the property 38 (installation date)', function(done) {
+    request
+    .get('/v1/items/'+global.itemId)
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect(200)
+    .expect('Content-Type', /json/)
+    .expect(function(response) {
+      assert(is.not.empty(response.body), 'The body must contain something');
+      assert(is.object(response.body), 'the body response must be an object');
+      assert(is.equal(2, response.body.properties.length), 'must have 2 properties');
+      assert(is.equal(38, response.body.properties[1].id), 'the second property id must be 38');
+    })
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+});

--- a/tests/RESTAPI/21_itemPropertyWhenAddDeletePropertyToType/6_deleteItem.js
+++ b/tests/RESTAPI/21_itemPropertyWhenAddDeletePropertyToType/6_deleteItem.js
@@ -1,0 +1,39 @@
+const supertest = require('supertest');
+const validator = require('validator');
+const assert = require('assert');
+const is = require('is_js');
+const { faker } = require('@faker-js/faker');
+
+const request = supertest('http://127.0.0.1/fusionsuite/backend');
+
+describe('itemPropertyWhenAddPropertyToType | delete item', function() {
+
+  it('Soft delete the item', function(done) {
+    request
+    .delete('/v1/items/' + global.itemId.toString())
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect('Content-Type', /json/)
+    .expect(200)
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+  it('Hard delete the item', function(done) {
+    request
+    .delete('/v1/items/' + global.itemId.toString())
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect('Content-Type', /json/)
+    .expect(200)
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+});

--- a/tests/RESTAPI/21_itemPropertyWhenAddDeletePropertyToType/7_deleteType.js
+++ b/tests/RESTAPI/21_itemPropertyWhenAddDeletePropertyToType/7_deleteType.js
@@ -1,0 +1,39 @@
+const supertest = require('supertest');
+const validator = require('validator');
+const assert = require('assert');
+const is = require('is_js');
+const { faker } = require('@faker-js/faker');
+
+const request = supertest('http://127.0.0.1/fusionsuite/backend');
+
+describe('itemPropertyWhenAddPropertyToType | delete type', function() {
+
+  it('Soft delete the type', function(done) {
+    request
+    .delete('/v1/config/types/' + global.typeId.toString())
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect('Content-Type', /json/)
+    .expect(200)
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+  it('Hard delete the type', function(done) {
+    request
+    .delete('/v1/config/types/' + global.typeId.toString())
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ' + global.token)
+    .expect('Content-Type', /json/)
+    .expect(200)
+    .end(function(err, response) {
+      if (err) {
+        return done(err + ' | Response: ' + response.text);
+      }
+      return done();
+    });
+  });
+});


### PR DESCRIPTION
… https://github.com/fusionSuite/FusionSuite/issues/66

Changes proposed in this pull request:

- Add code to add/delete properties on items yet created when add/delete a property to the type

How to test the feature manually:

1. create an item
2. add a property to the type
3. get the item created before and check if property set
4. do the same for delete property

Pull request checklist:

- [x] code is manually tested
- [x] tests are updated
- [x] commit messages are relevant
- [x] documentation is updated (including code comments, commit messages…)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and precise `N/A` next to it._

Related to #
