### PR TITLE
Simplify models by adding attributes cast. closes https://github.com/…

### DIFF
--- a/src/v1/Models/Config/Permissiondata.php
+++ b/src/v1/Models/Config/Permissiondata.php
@@ -42,6 +42,20 @@ class Permissiondata extends Model
     'properties'
   ];
 
+  /**
+   * The attributes that should be cast.
+   *
+   * @var array
+   */
+  protected $casts = [
+    'view'             => 'boolean',
+    'create'           => 'boolean',
+    'update'           => 'boolean',
+    'softdelete'       => 'boolean',
+    'delete'           => 'boolean',
+    'propertiescustom' => 'boolean',
+  ];
+
   public static function boot()
   {
     parent::boot();
@@ -54,36 +68,6 @@ class Permissiondata extends Model
     {
       $model->updated_by = $GLOBALS['user_id'];
     });
-  }
-
-  public function getViewAttribute($value)
-  {
-    return boolval($value);
-  }
-
-  public function getCreateAttribute($value)
-  {
-    return boolval($value);
-  }
-
-  public function getUpdateAttribute($value)
-  {
-    return boolval($value);
-  }
-
-  public function getSoftdeleteAttribute($value)
-  {
-    return boolval($value);
-  }
-
-  public function getDeleteAttribute($value)
-  {
-    return boolval($value);
-  }
-
-  public function getPropertiescustomAttribute($value)
-  {
-    return boolval($value);
   }
 
   public function getRoleAttribute()

--- a/src/v1/Models/Config/Permissiondataproperty.php
+++ b/src/v1/Models/Config/Permissiondataproperty.php
@@ -35,6 +35,16 @@ class Permissiondataproperty extends Model
     'update'
   ];
 
+  /**
+   * The attributes that should be cast.
+   *
+   * @var array
+   */
+  protected $casts = [
+    'view'   => 'boolean',
+    'update' => 'boolean',
+  ];
+
   public static function boot()
   {
     parent::boot();
@@ -57,16 +67,6 @@ class Permissiondataproperty extends Model
       'name'         => $property->name,
       'internalname' => $property->internalname
     ];
-  }
-
-  public function getViewAttribute($value)
-  {
-    return boolval($value);
-  }
-
-  public function getUpdateAttribute($value)
-  {
-    return boolval($value);
   }
 
   public function permissiondata()

--- a/src/v1/Models/Config/Permissionstructurecustom.php
+++ b/src/v1/Models/Config/Permissionstructurecustom.php
@@ -36,6 +36,18 @@ class Permissionstructurecustom extends Model
     'delete'
   ];
 
+  /**
+   * The attributes that should be cast.
+   *
+   * @var array
+   */
+  protected $casts = [
+    'view'       => 'boolean',
+    'update'     => 'boolean',
+    'softdelete' => 'boolean',
+    'delete'     => 'boolean',
+  ];
+
   public static function boot()
   {
     parent::boot();
@@ -58,26 +70,6 @@ class Permissionstructurecustom extends Model
       'name'         => $property->name,
       'internalname' => $property->internalname
     ];
-  }
-
-  public function getViewAttribute($value)
-  {
-    return boolval($value);
-  }
-
-  public function getUpdateAttribute($value)
-  {
-    return boolval($value);
-  }
-
-  public function getSoftdeleteAttribute($value)
-  {
-    return boolval($value);
-  }
-
-  public function getDeleteAttribute($value)
-  {
-    return boolval($value);
   }
 
   public function permissionstructure()

--- a/src/v1/Models/Config/Property.php
+++ b/src/v1/Models/Config/Property.php
@@ -49,6 +49,16 @@ class Property extends Model
     'regexformat'
   ];
 
+  /**
+   * The attributes that should be cast.
+   *
+   * @var array
+   */
+  protected $casts = [
+    'sub_organization' => 'boolean',
+    'canbenull'        => 'boolean',
+  ];
+
   protected $hidden = [];
   protected $with = [];
 
@@ -107,11 +117,6 @@ class Property extends Model
       'id'   => $org->id,
       'name' => $org->name
     ];
-  }
-
-  public function getSubOrganizationAttribute($value)
-  {
-    return boolval($value);
   }
 
   public function getCreatedByAttribute($value)
@@ -227,11 +232,6 @@ class Property extends Model
       return floatval($this->{'default_decimal'});
     }
     return $this->{'default_' . $valuetype};
-  }
-
-  public function getCanbenullAttribute($value)
-  {
-    return boolval($value);
   }
 
   public function getSetcurrentdateAttribute($value)

--- a/src/v1/Models/Config/Type.php
+++ b/src/v1/Models/Config/Type.php
@@ -58,6 +58,18 @@ class Type extends Model
     'properties'
   ];
 
+  /**
+   * The attributes that should be cast.
+   *
+   * @var array
+   */
+  protected $casts = [
+    'sub_organization'       => 'boolean',
+    'tree'                   => 'boolean',
+    'allowtreemultipleroots' => 'boolean',
+    'unique_name'            => 'boolean',
+  ];
+
   public static function boot()
   {
     parent::boot();
@@ -95,11 +107,6 @@ class Type extends Model
     ];
   }
 
-  public function getSubOrganizationAttribute($value)
-  {
-    return boolval($value);
-  }
-
   public function getCreatedByAttribute($value)
   {
     return \App\v1\Models\Common::getUserAttributes($value);
@@ -115,16 +122,6 @@ class Type extends Model
     return \App\v1\Models\Common::getUserAttributes($value);
   }
 
-  public function getTreeAttribute($value)
-  {
-    return boolval($value);
-  }
-
-  public function getAllowtreemultiplerootsAttribute($value)
-  {
-    return boolval($value);
-  }
-
   public function getPropertiesAttribute()
   {
     return [];
@@ -133,11 +130,6 @@ class Type extends Model
   public function getPropertygroupsAttribute()
   {
     return $this->propertygroups()->get();
-  }
-
-  public function getUniqueNameAttribute($value)
-  {
-    return boolval($value);
   }
 
 

--- a/src/v1/Models/Item.php
+++ b/src/v1/Models/Item.php
@@ -58,6 +58,15 @@ class Item extends Model
   ];
   protected $fillable = ['name', 'type_id'];
 
+  /**
+   * The attributes that should be cast.
+   *
+   * @var array
+   */
+  protected $casts = [
+    'sub_organization' => 'boolean',
+  ];
+
   public static function boot()
   {
     parent::boot();
@@ -155,11 +164,6 @@ class Item extends Model
       'id'   => $org->id,
       'name' => $org->name
     ];
-  }
-
-  public function getSubOrganizationAttribute($value)
-  {
-    return boolval($value);
   }
 
   public function getCreatedByAttribute($value)


### PR DESCRIPTION
…fusionSuite/FusionSuite/issues/67

Changes proposed in this pull request:

- use attributes cast to return boolean directly when get model data

How to test the feature manually:

1. return fields with boolean like before

Pull request checklist:

- [x] code is manually tested
- [ ] tests are updated N/A because same tests
- [x] commit messages are relevant
- [x] documentation is updated (including code comments, commit messages…)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and precise `N/A` next to it._

Related to #
