### PR TITLE
Add changeslogs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         "hoa/ruler": "^2.17.05.16",
         "illuminate/events": "^8.73",
         "rakit/validation": "^1.4",
-        "adhocore/cli": "^0.9.0"
+        "adhocore/cli": "^0.9.0",
+        "genealabs/laravel-pivot-events": "^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "20f787387b9371220c8114a5eff22207",
+    "content-hash": "40408e36805b0fb389e6e64c97aef6ae",
     "packages": [
         {
             "name": "adhocore/cli",
@@ -505,6 +505,61 @@
                 "source": "https://github.com/firebase/php-jwt/tree/v5.5.1"
             },
             "time": "2021-11-08T20:18:51+00:00"
+        },
+        {
+            "name": "genealabs/laravel-pivot-events",
+            "version": "8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/GeneaLabs/laravel-pivot-events.git",
+                "reference": "aafc9d7f6a0b31e0d58bd2b31e38253fbd27c2a9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/GeneaLabs/laravel-pivot-events/zipball/aafc9d7f6a0b31e0d58bd2b31e38253fbd27c2a9",
+                "reference": "aafc9d7f6a0b31e0d58bd2b31e38253fbd27c2a9",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/database": "^8.0",
+                "illuminate/support": "^8.0"
+            },
+            "require-dev": {
+                "orchestra/testbench": "^6.0",
+                "symfony/thanks": "^1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "GeneaLabs\\LaravelPivotEvents\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike Bronner",
+                    "email": "hello@genealabs.com",
+                    "homepage": "https://genealabs.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "This package introduces new eloquent events for sync(), attach(), detach() or updateExistingPivot() methods on BelongsToMany relation.",
+            "homepage": "https://github.com/fico7489/laravel-pivot",
+            "keywords": [
+                "eloquent events",
+                "eloquent extra events",
+                "laravel BelongsToMany events",
+                "laravel pivot events",
+                "laravel sync events"
+            ],
+            "support": {
+                "issues": "https://github.com/fico7489/laravel-pivot/issues",
+                "source": "https://github.com/fico7489/laravel-pivot"
+            },
+            "time": "2020-09-08T14:39:12+00:00"
         },
         {
             "name": "hoa/compiler",

--- a/db/migrations/20200719120001_changes.php
+++ b/db/migrations/20200719120001_changes.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * FusionSuite - Frontend
+ * Copyright (C) 2022 FusionSuite
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+use Phinx\Db\Adapter\MysqlAdapter;
+
+final class Changes extends AbstractMigration
+{
+  /**
+   * Change Method.
+   *
+   * Write your reversible migrations using this method.
+   *
+   * More information on writing migrations is available here:
+   * https://book.cakephp.org/phinx/0/en/migrations.html#the-change-method
+   *
+   * Remember to call "create()" or "update()" and NOT "save()" when working
+   * with the Table class.
+   */
+  public function change(): void
+  {
+    // create the table
+    $table = $this->table('changes');
+    $table->addColumn('userid', 'integer', ['null' => true])
+          ->addColumn('username', 'string', ['null' => true])
+          ->addColumn('model_type', 'string')
+          ->addColumn('model_id', 'integer')
+          ->addColumn('property_name', 'string', ['null' => true])
+          ->addColumn('property_id', 'integer', ['null' => true])
+          ->addColumn('set_by_rule', 'boolean', ['default' => false])
+          ->addColumn('message', 'text', ['null' => true, 'limit' => MysqlAdapter::TEXT_LONG])
+          ->addColumn('old_value', 'text', ['null' => true, 'limit' => MysqlAdapter::TEXT_LONG])
+          ->addColumn('new_value', 'text', ['null' => true, 'limit' => MysqlAdapter::TEXT_LONG])
+          ->addColumn('created_at', 'datetime')
+          ->create();
+  }
+}

--- a/public/index.php
+++ b/public/index.php
@@ -125,7 +125,7 @@ $customErrorHandler = function (
     $response->getBody()->write(json_encode($error));
     return $response->withStatus(409)->withHeader('Content-Type', 'application/json');
   }
-  elseif ($exception->getCode() > 0)
+  elseif (is_int($exception->getCode()) && $exception->getCode() > 0)
   {
     if (strstr($request->getUri()->getPath(), 'refreshtoken'))
     {

--- a/src/v1/Controllers/Config/Property.php
+++ b/src/v1/Controllers/Config/Property.php
@@ -322,6 +322,7 @@ final class Property
 
     $item->makeHidden(['value', 'byfusioninventory'])
     ->makeVisible($this->getVisibleFields());
+    $item->makeVisible('changes');
 
     $response->getBody()->write($item->toJson());
     return $response->withHeader('Content-Type', 'application/json');
@@ -511,7 +512,8 @@ final class Property
   {
     $token = (object)$request->getAttribute('token');
 
-    $property = \App\v1\Models\Config\Property::withTrashed()->find($args['id']);
+    $property = \App\v1\Models\Config\Property::withTrashed()
+    ->find($args['id']);
 
     if (is_null($property))
     {
@@ -547,6 +549,8 @@ final class Property
         'Config\Property',
         $property->id
       );
+      $property->makeHidden(['value', 'byfusioninventory'])
+      ->makeVisible($this->getVisibleFields());
       $property->forceDelete();
 
       // Post delete actions
@@ -926,10 +930,10 @@ final class Property
     {
       $properties['description'] = $data->description;
     }
-    if (property_exists($data, 'canbenull') && !$data->canbenull)
+    if (property_exists($data, 'canbenull'))
     {
-      $properties['canbenull'] = false;
-      if (property_exists($data, 'default') && is_null($data->default))
+      $properties['canbenull'] = $data->canbenull;
+      if (property_exists($data, 'default') && !$data->canbenull && is_null($data->default))
       {
         throw new \Exception('The Default can\'t be null', 400);
       }

--- a/src/v1/Controllers/Config/Type.php
+++ b/src/v1/Controllers/Config/Type.php
@@ -306,6 +306,8 @@ final class Type
       throw new \Exception("This type is not in your organization", 403);
     }
 
+    $item->makeVisible('changes');
+
     $response->getBody()->write($item->toJson());
     return $response->withHeader('Content-Type', 'application/json');
   }
@@ -471,6 +473,7 @@ final class Type
       \App\v1\Permission::checkPermissionToStructure('delete', 'config/type', $type->id);
 
       \App\v1\Controllers\Log\Audit::addEntry($request, 'DELETE', '', 'Config\Type', $type->id);
+      $type->properties()->detach();
       $type->forceDelete();
 
       // Post delete actions
@@ -482,7 +485,6 @@ final class Type
       \App\v1\Permission::checkPermissionToStructure('softdelete', 'config/type', $type->id);
 
       \App\v1\Controllers\Log\Audit::addEntry($request, 'SOFTDELETE', '', 'Config\Type', $type->id);
-      $type->properties()->detach();
       $type->delete();
     }
 

--- a/src/v1/Controllers/Log/Change.php
+++ b/src/v1/Controllers/Log/Change.php
@@ -1,0 +1,152 @@
+<?php
+
+/**
+ * FusionSuite - Backend
+ * Copyright (C) 2022 FusionSuite
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace App\v1\Controllers\Log;
+
+final class Change
+{
+  use \App\v1\Read;
+
+  /**
+   *
+   * $old_value / $new_value any (string, integer...), but if object :
+   * object   {
+   *   item: {
+   *     id: number|null,
+   *     name: string|null
+   *   },
+   *   type: {
+   *     id: number|null,
+   *     name: string|null
+   *   }
+   * }
+   */
+  public static function addEntry(
+    $model,
+    $message,
+    $new_value,
+    $old_value = null,
+    $property = null,
+    $set_by_rule = false
+  )
+  {
+    $change = new \App\v1\Models\Log\Change();
+    $change->userid = $GLOBALS['user_id'];
+    $user = \App\v1\Models\Item::find($GLOBALS['user_id']);
+    // Store the name in case the user account deleted later
+    if (!is_null($user))
+    {
+      $change->username = $user->name;
+    }
+    if (is_object($model))
+    {
+      $change->model_type = get_class($model);
+      $change->model_id = $model->id;
+    } else {
+      $change->model_type = $model;
+      $change->model_id = 0;
+    }
+
+    $change->set_by_rule = $set_by_rule;
+    if (!is_null($property))
+    {
+      $change->property_name = $property->name;
+      $change->property_id = $property->id;
+    }
+
+    // mapping conversion in message
+    $changelogs = new self();
+    $message = $changelogs->mappingReplace($message, 'old', $old_value, $property, $user);
+    $message = $changelogs->mappingReplace($message, 'new', $new_value, $property, $user);
+
+    if (is_object($old_value))
+    {
+      $change->old_value = json_encode(['id' => $old_value->item->id, 'name' => $old_value->item->name]);
+    } else {
+      $change->old_value = $old_value;
+    }
+
+    if (is_object($new_value))
+    {
+      $change->new_value = json_encode(['id' => $new_value->item->id, 'name' => $new_value->item->name]);
+    } else {
+      $change->new_value = $new_value;
+    }
+
+    $change->message = $message;
+    $change->save();
+  }
+
+  /**
+   * $type string old|new
+   */
+  private function mappingReplace($message, $type, $value, $property, $user)
+  {
+    if (!in_array($type, ['old', 'new']))
+    {
+      return $message;
+    }
+    // replace user name
+    if (is_object($user))
+    {
+      $message = str_replace('{username}', $user->name, $message);
+    } else {
+      $message = str_replace('{username}', 'N/A', $message);
+    }
+
+    if (!is_null($property))
+    {
+      $message = str_replace('{property.id}', $property->id, $message);
+      $message = str_replace('{property.name}', $property->name, $message);
+    }
+
+    if (is_null($value))
+    {
+      return $message;
+    }
+
+    if (is_object($value))
+    {
+      if (property_exists($value, 'item'))
+      {
+        $message = str_replace('{' . $type . '_value.item.id}', $value->item->id, $message);
+        $message = str_replace('{' . $type . '_value.item.name}', $value->item->name, $message);
+      }
+      if (property_exists($value, 'type'))
+      {
+        $message = str_replace('{' . $type . '_value.type.id}', $value->type->id, $message);
+        $message = str_replace('{' . $type . '_value.type.name}', $value->type->name, $message);
+      }
+    } else {
+      $message = str_replace('{' . $type . '_value}', $this->reduceName($value), $message);
+    }
+    return $message;
+  }
+
+  private function reduceName($value)
+  {
+    if (!is_string($value))
+    {
+      return $value;
+    }
+    $name = explode(PHP_EOL, $value);
+    return strlen($name[0]) > 50 ? substr($name[0], 0, 50) . '...' : $name[0];
+  }
+}

--- a/src/v1/Models/Common.php
+++ b/src/v1/Models/Common.php
@@ -81,4 +81,395 @@ class Common
     }
     return $query->orderBy('id');
   }
+
+  /**
+   * Add in changes when update fields
+   */
+  public static function changesOnUpdated($model, $original)
+  {
+    $changes = $model->getChanges();
+    $casts = $model->getCasts();
+    foreach ($changes as $key => $newValue)
+    {
+      if (in_array($key, ['created_at', 'updated_at', 'deleted_at', 'created_by', 'updated_by', 'deleted_by']))
+      {
+        continue;
+      }
+      $oldValue = $original[$key];
+      if (isset($casts[$key]) && $casts[$key] == 'boolean')
+      {
+        $newValue = (boolval($newValue) ? 'true' : 'false');
+        $oldValue = (boolval($oldValue) ? 'true' : 'false');
+      }
+      \App\v1\Controllers\Log\Change::addEntry(
+        $model,
+        '{username} changed ' . $key . ' to "{new_value}"',
+        $newValue,
+        $oldValue,
+      );
+    }
+  }
+
+  public static function changesOnDeleted($model, $original)
+  {
+    \App\v1\Controllers\Log\Change::addEntry(
+      $model,
+      '{username} deleted this item',
+      'hard delete',
+      $model->toJson(),
+    );
+  }
+
+  public static function changesOnSoftDeleted($model)
+  {
+    \App\v1\Controllers\Log\Change::addEntry(
+      $model,
+      '{username} soft deleted this item',
+      'soft delete',
+      '',
+    );
+  }
+
+  public static function changesOnRestored($model)
+  {
+    \App\v1\Controllers\Log\Change::addEntry(
+      $model,
+      '{username} restored this item',
+      'restored',
+      '',
+    );
+  }
+
+  public static function changesOnPivotUpdated($model, $pivotIds, $pivotIdsAttributes)
+  {
+    if (isset($GLOBALS['no-changes']) && $GLOBALS['no-changes'])
+    {
+      return;
+    }
+    foreach ($pivotIds as $propertyId)
+    {
+      $property = \App\v1\Models\Config\Property::find($propertyId);
+      // Special case for refreshtoken to not put in changes
+      if ($property->internalname == 'userrefreshtoken') {
+        continue;
+      }
+      $newValue = array_values($pivotIdsAttributes[$propertyId])[0];
+      $oldValue = null;
+      if (isset($model->oldProperties[$propertyId]))
+      {
+        $oldValue = $model->oldProperties[$propertyId];
+      }
+      $message = '{username} changed ' . strtolower($property->name) . ' to "{new_value}"';
+
+      switch ($property->valuetype) {
+        case 'boolean':
+          if (!is_null($newValue))
+          {
+            $newValue = (boolval($newValue) ? 'true' : 'false');
+          }
+          if (!is_null($oldValue))
+          {
+            $oldValue = (boolval($oldValue) ? 'true' : 'false');
+          }
+            break;
+
+        case 'list':
+          if (!is_null($newValue))
+          {
+            $propertylist = $property->listvalues()->where('id', $newValue)->first();
+            $newValue = $propertylist->value;
+          }
+          if (!is_null($oldValue))
+          {
+            $oldValue = $oldValue->value;
+          }
+            break;
+
+        case 'itemlink':
+          if (!is_null($newValue))
+          {
+            $itemlink = \App\v1\Models\Item::find($newValue);
+            $type = \App\v1\Models\Config\Type::find($itemlink->type_id);
+            $newValue = (object)[
+              'item' => (object)[
+                'id'   => $itemlink->id,
+                'name' => $itemlink->name
+              ],
+              'type' => (object)[
+                'id'   => $type->id,
+                'name' => $type->name
+              ],
+            ];
+          }
+
+          if (!is_null($oldValue))
+          {
+            $type = \App\v1\Models\Config\Type::find($oldValue->type_id);
+            $oldValue = (object)[
+              'item' => (object)[
+                'id'   => $oldValue->id,
+                'name' => $oldValue->name
+              ],
+              'type' => (object)[
+                'id'   => $type->id,
+                'name' => $type->name
+              ],
+            ];
+          }
+          $message = '{username} changed "{property.name}" to "{new_value.item.name}"';
+            break;
+
+        case 'propertylink':
+          if (!is_null($newValue))
+          {
+            $propertylink = \App\v1\Models\Config\Property::find($newValue);
+            $newValue = (object)[
+              'item' => (object)[
+                'id'   => $propertylink->id,
+                'name' => $propertylink->name
+              ],
+            ];
+          }
+
+          if (!is_null($oldValue))
+          {
+            $propertylink = $oldValue;
+            $oldValue = (object)[
+              'item' => (object)[
+                'id'   => $propertylink->id,
+                'name' => $propertylink->name
+              ],
+            ];
+          }
+          $message = '{username} changed "{property.name}" to "{new_value.item.name}"';
+            break;
+
+        case 'typelink':
+          if (!is_null($newValue))
+          {
+            $typelink = \App\v1\Models\Config\Type::find($newValue);
+            $newValue = (object)[
+              'item' => (object)[
+                'id'   => $typelink->id,
+                'name' => $typelink->name
+              ],
+              'type' => (object)[
+                'id'   => $typelink->id,
+                'name' => $typelink->name
+              ],
+            ];
+          }
+
+          if (!is_null($oldValue))
+          {
+            $typelink = $oldValue;
+            $oldValue = (object)[
+              'item' => (object)[
+                'id'   => $typelink->id,
+                'name' => $typelink->name
+              ],
+              'type' => (object)[
+                'id'   => $typelink->id,
+                'name' => $typelink->name
+              ],
+            ];
+          }
+          $message = '{username} changed "{property.name}" to "{new_value.item.name}"';
+            break;
+      }
+
+      \App\v1\Controllers\Log\Change::addEntry(
+        $model,
+        $message,
+        $newValue,
+        $oldValue,
+        $property
+      );
+    }
+  }
+
+  public static function changesOnPivotAttached($model, $pivotIds, $pivotIdsAttributes)
+  {
+    if (isset($GLOBALS['no-changes']) && $GLOBALS['no-changes'])
+    {
+      return;
+    }
+    foreach ($pivotIds as $propertyId)
+    {
+      $property = \App\v1\Models\Config\Property::find($propertyId);
+      // Special case for refreshtoken to not put in changes
+      if ($property->internalname == 'userrefreshtoken') {
+        continue;
+      }
+      $newValue = array_values($pivotIdsAttributes[$propertyId])[0];
+      $oldValue = null;
+      if (isset($model->oldProperties[$propertyId]))
+      {
+        $oldValue = $model->oldProperties[$propertyId];
+      }
+      $message = '{username} added "{property.name}" to "{new_value}"';
+
+      switch ($property->valuetype) {
+        case 'boolean':
+          if (!is_null($newValue))
+          {
+            $newValue = (boolval($newValue) ? 'true' : 'false');
+          }
+          if (!is_null($oldValue))
+          {
+            $oldValue = (boolval($oldValue) ? 'true' : 'false');
+          }
+            break;
+
+        case 'list':
+          $propertylist = $property->listvalues()->where('id', $newValue->value)->first();
+          $newValue->value = $propertylist->value;
+          $oldValue->value = $oldValue->value->value;
+            break;
+
+        case 'itemlink':
+          $itemlink = \App\v1\Models\Item::find($newValue);
+          $type = \App\v1\Models\Config\Type::find($itemlink->type_id);
+          $newValue = (object)[
+            'item' => (object)[
+              'id'   => $itemlink->id,
+              'name' => $itemlink->name
+            ],
+            'type' => (object)[
+              'id'   => $type->id,
+              'name' => $type->name
+            ],
+          ];
+          $message = '{username} changed "{property.name}" to "{new_value.item.name}"';
+            break;
+
+        case 'itemlinks':
+          if (is_null($newValue))
+          {
+            $newValue = null;
+            $message = '{username} added null to "{property.name}"';
+          } else {
+            $itemlink = \App\v1\Models\Item::find($newValue);
+            $type = \App\v1\Models\Config\Type::find($itemlink->type_id);
+            $newValue = (object)[
+              'item' => (object)[
+                'id'   => $itemlink->id,
+                'name' => $itemlink->name
+              ],
+              'type' => (object)[
+                'id'   => $type->id,
+                'name' => $type->name
+              ],
+            ];
+            $message = '{username} added "{new_value.item.name}" ({new_value.type.name}) to "{property.name}"';
+          }
+            break;
+
+        case 'typelinks':
+          if (is_null($newValue))
+          {
+            $newValue = null;
+            $message = '{username} added null to "{property.name}"';
+          } else {
+            $typelink = \App\v1\Models\Config\Type::find($newValue);
+            $newValue = (object)[
+              'item' => (object)[
+                'id'   => $typelink->id,
+                'name' => $typelink->name
+              ],
+              'type' => (object)[
+                'id'   => $typelink->id,
+                'name' => $typelink->name
+              ],
+            ];
+            $message = '{username} added "{new_value.type.name}" to "{property.name}"';
+          }
+            break;
+      }
+
+      \App\v1\Controllers\Log\Change::addEntry(
+        $model,
+        $message,
+        $newValue,
+        $oldValue,
+        $property
+      );
+    }
+  }
+
+  public static function changesOnPivotDetached($model, $pivotIds, $pivotIdsAttributes)
+  {
+    if (isset($GLOBALS['no-changes']) && $GLOBALS['no-changes'])
+    {
+      return;
+    }
+    foreach ($pivotIds as $propertyId)
+    {
+      $property = \App\v1\Models\Config\Property::find($propertyId);
+      // Special case for refreshtoken to not put in changes
+      if ($property->internalname == 'userrefreshtoken') {
+        continue;
+      }
+      $newValue = null;
+      $oldValue = null;
+      if (isset($model->oldProperties[$propertyId]))
+      {
+        $oldValue = $model->oldProperties[$propertyId];
+      }
+      $message = '{username} deleted "{old_value}" (property.name)';
+
+      switch ($property->valuetype) {
+        case 'boolean':
+          if (!is_null($newValue))
+          {
+            $newValue = (boolval($newValue) ? 'true' : 'false');
+          }
+          if (!is_null($oldValue))
+          {
+            $oldValue = (boolval($oldValue) ? 'true' : 'false');
+          }
+            break;
+
+        case 'list':
+          // $propertylist = $property->listvalues()->where('id', $newValue->value)->first();
+          // $newValue->value = $propertylist->value;
+          // $oldValue->value = $oldValue->value->value;
+            break;
+
+        case 'itemlink':
+          $itemlink = \App\v1\Models\Item::find($newValue);
+          $type = \App\v1\Models\Config\Type::find($itemlink->type_id);
+          $newValue = (object)[
+            'item' => [
+              'id'   => $itemlink->id,
+              'name' => $itemlink->name
+            ],
+            'type' => [
+              'id'   => $type->id,
+              'name' => $type->name
+            ],
+          ];
+          $message = '{username} changed "{property.name}" to "{new_value.item.name}"';
+            break;
+
+        case 'itemlinks':
+          $newValue = \App\v1\Models\Item::find($newValue);
+          $message = '{username} deleted property "{property.name}" named "{old_value.item.name}"';
+            break;
+
+        case 'typelinks':
+          $newValue = \App\v1\Models\Config\Type::find($newValue);
+          $message = '{username} deleted property "{property.name}" named "{old_value.type.name}"';
+            break;
+      }
+
+      \App\v1\Controllers\Log\Change::addEntry(
+        $model,
+        $message,
+        $newValue,
+        $oldValue,
+        $property
+      );
+    }
+  }
 }

--- a/src/v1/Models/Log/Change.php
+++ b/src/v1/Models/Log/Change.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * FusionSuite - Backend
+ * Copyright (C) 2022 FusionSuite
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace App\v1\Models\Log;
+
+use Illuminate\Database\Eloquent\Model as Model;
+
+class Change extends Model
+{
+  // disable UPDATED_AT because will have only write in this table
+  public const UPDATED_AT = null;
+
+  protected $appends = [
+    'user'
+  ];
+  protected $visible = [
+    'id',
+    'user',
+    'username',
+    'set_by_rule',
+    'message',
+    'old_value',
+    'new_value',
+    'created_at'
+  ];
+
+  public function getUserAttribute()
+  {
+    return \App\v1\Models\Common::getUserAttributes($this->attributes['userid']);
+  }
+
+  public function scopeofSort($query, $params)
+  {
+    return \App\v1\Models\Common::scopeofSort($query, $params);
+  }
+
+  /**
+   * Get the parent model.
+   */
+  public function model()
+  {
+    return $this->morphTo();
+  }
+}

--- a/src/v1/Templates/incident_contracts.json
+++ b/src/v1/Templates/incident_contracts.json
@@ -1,0 +1,113 @@
+{
+  "license": [
+    " FusionSuite - Backend                                                       ",
+    " Copyright (C) 2022 FusionSuite                                              ",
+    "                                                                             ",
+    " This program is free software: you can redistribute it and/or modify        ",
+    " it under the terms of the GNU Affero General Public License as published by ",
+    " the Free Software Foundation, either version 3 of the License, or           ",
+    " any later version.                                                          ",
+    "                                                                             ",
+    " This program is distributed in the hope that it will be useful,             ",
+    " but WITHOUT ANY WARRANTY; without even the implied warranty of              ",
+    " MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                ",
+    " GNU Affero General Public License for more details.                         ",
+    "                                                                             ",
+    " You should have received a copy of the GNU Affero General Public License    ",
+    " along with this program.  If not, see <http://www.gnu.org/licenses/>.       "
+  ],
+  "types": [
+    {
+      "name": "Contract",
+      "internalname": "contract",
+      "propertygroups": [
+        {
+          "name": "Main",
+          "properties": [
+            {
+              "name": "Description",
+              "internalname": "description",
+              "valuetype": "text",
+              "regexformat": "",
+              "listvalues": [],
+              "unit": "",
+              "default": "",
+              "description": ""
+            },
+            {
+              "name": "time spent",
+              "internalname": "incidentmessagetime",
+              "valuetype": "number",
+              "regexformat": "",
+              "listvalues": [],
+              "unit": "seconds",
+              "default": 0,
+              "description": "time spent"
+            },
+            {
+              "name": "Contract timebought",
+              "internalname": "contracttimebought",
+              "valuetype": "number",
+              "regexformat": "",
+              "listvalues": [],
+              "unit": "seconds",
+              "default": 36000,
+              "description": "time bought by client in seconds, by default 10 hours"
+            },
+            {
+              "name": "Contract begin date",
+              "internalname": "contractbegindate",
+              "valuetype": "date",
+              "regexformat": "",
+              "listvalues": [],
+              "unit": "",
+              "default": null,
+              "description": ""
+            },
+            {
+              "name": "Contract end date",
+              "internalname": "contractenddate",
+              "valuetype": "date",
+              "regexformat": "",
+              "listvalues": [],
+              "unit": "",
+              "default": null,
+              "description": ""
+            },
+            {
+              "name": "Type",
+              "internalname": "contracttype",
+              "valuetype": "list",
+              "regexformat": "",
+              "listvalues": [],
+              "unit": "",
+              "default": null,
+              "description": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Ticket",
+      "internalname": "ticket",
+      "propertygroups": [
+        {
+          "name": "Contracts",
+          "properties": [
+            {
+              "name": "Contract",
+              "internalname": "contractlink",
+              "valuetype": "itemlink",
+              "regexformat": "",
+              "listvalues": ["contract"],
+              "unit": "",
+              "default": null,
+              "description": ""
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/RESTAPI/02_items/4_type-items-POST.js
+++ b/tests/RESTAPI/02_items/4_type-items-POST.js
@@ -60,7 +60,7 @@ describe('items | Endpoint /v1/items', function () {
         })
         .end(function (err, response) {
           if (err) {
-            return done(err + ' | Response: ' + response.text);
+            return done(err + ' ' + name + ' ' + ' | Response: ' + response.text);
           }
         });
     }

--- a/tests/RESTAPI/22_changeslogs/1_properties/1_create_property.js
+++ b/tests/RESTAPI/22_changeslogs/1_properties/1_create_property.js
@@ -1,0 +1,93 @@
+const supertest = require('supertest');
+const validator = require('validator');
+const assert = require('assert');
+const is = require('is_js');
+
+const request = supertest('http://127.0.0.1/fusionsuite/backend');
+const requestDB = supertest('http://127.0.0.1:8012');
+
+describe('changes | properties | create a property', function () {
+  it('initial number of changes rows in database table', function (done) {
+    requestDB
+      .get('/count/changes')
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        global.changesCnt = response.body.count;
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.body);
+        }
+        return done();
+      });
+  });
+
+  it('create a new property', function (done) {
+    request
+      .post('/v1/config/properties')
+      .send({
+        name: 'Test for string',
+        internalname: 'testforstring',
+        valuetype: 'string',
+        regexformat: '',
+        listvalues: [],
+        unit: '',
+        default: 'default value',
+        description: 'Test of the type string',
+        canbenull: false,
+      })
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.propertyCount(response.body, 1));
+        assert(is.integer(response.body.id));
+        assert(validator.matches('' + response.body.id, /^\d+$/));
+        global.propertyId = response.body.id;
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('get the property and check if changes empty', function (done) {
+    request
+      .get('/v1/config/properties/' + global.propertyId)
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.not.empty(response.body));
+        assert(is.equal('Test for string', response.body.name));
+        assert(is.propertyDefined(response.body, 'changes'));
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('check changes rows in database table - must not have more changes', function (done) {
+    requestDB
+      .get('/count/changes/' + global.changesCnt)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.equal(global.changesCnt, response.body.count));
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.body);
+        }
+        return done();
+      });
+  });
+});

--- a/tests/RESTAPI/22_changeslogs/1_properties/2_getall_properties.js
+++ b/tests/RESTAPI/22_changeslogs/1_properties/2_getall_properties.js
@@ -1,0 +1,29 @@
+const supertest = require('supertest');
+const assert = require('assert');
+const is = require('is_js');
+
+const request = supertest('http://127.0.0.1/fusionsuite/backend');
+
+describe('changes | properties | get all properties', function () {
+  it('get all properties and check changes key not exists', function (done) {
+    request
+      .get('/v1/config/properties')
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.array(response.body));
+        assert(is.above(response.body.length, 2));
+
+        const firstProperty = response.body[0];
+        assert(is.not.propertyDefined(firstProperty, 'changes'));
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+});

--- a/tests/RESTAPI/22_changeslogs/1_properties/3_update_property.js
+++ b/tests/RESTAPI/22_changeslogs/1_properties/3_update_property.js
@@ -1,0 +1,151 @@
+const supertest = require('supertest');
+const assert = require('assert');
+const is = require('is_js');
+
+const request = supertest('http://127.0.0.1/fusionsuite/backend');
+const requestDB = supertest('http://127.0.0.1:8012');
+
+describe('changes | properties | update a property', function () {
+  it('Update name of the property', function (done) {
+    request
+      .patch('/v1/config/properties/' + global.propertyId)
+      .send(
+        {
+          name: 'test for a new name of the property',
+        })
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('get the property and check if changes has one entry', function (done) {
+    request
+      .get('/v1/config/properties/' + global.propertyId)
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.not.empty(response.body));
+        assert(is.equal('test for a new name of the property', response.body.name));
+        assert(is.propertyDefined(response.body, 'changes'));
+        assert(is.equal(1, response.body.changes.length), 'must have 1 changes');
+        const firstChanges = response.body.changes[0];
+        assert(is.equal('admin', firstChanges.username), 'must have username = admin');
+        assert(is.equal('Test for string', firstChanges.old_value), 'old value is wrong');
+        assert(is.equal('test for a new name of the property', firstChanges.new_value), 'new value is wrong');
+        assert(is.equal('admin changed name to "test for a new name of the property"', firstChanges.message), 'wrong message');
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('check changes rows in database table - must have only 1 rows more', function (done) {
+    requestDB
+      .get('/count/changes/' + global.changesCnt)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        global.changesCnt += 1;
+        assert(is.equal(global.changesCnt, response.body.count), 'have ' + response.body.count + ' instead ' + global.changesCnt);
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.body);
+        }
+        return done();
+      });
+  });
+
+  it('Update name, unit and canbenull of the property', function (done) {
+    request
+      .patch('/v1/config/properties/' + global.propertyId)
+      .send({
+        name: 'original name ;)',
+        unit: 'smileys',
+        canbenull: true,
+      })
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('get the property and check if changes has 4 entries', function (done) {
+    request
+      .get('/v1/config/properties/' + global.propertyId)
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.not.empty(response.body));
+        assert(is.equal('original name ;)', response.body.name));
+        assert(is.propertyDefined(response.body, 'changes'));
+        assert(is.equal(4, response.body.changes.length), 'must have 4 changes');
+        const firstChanges = response.body.changes[0];
+        assert(is.equal('admin', firstChanges.username), 'must have username = admin');
+        assert(is.equal('Test for string', firstChanges.old_value), 'old value is wrong');
+        assert(is.equal('test for a new name of the property', firstChanges.new_value), 'new value is wrong');
+        assert(is.equal('admin changed name to "test for a new name of the property"', firstChanges.message), 'wrong message');
+
+        const secondChanges = response.body.changes[1];
+        assert(is.equal('admin', secondChanges.username), 'second - must have username = admin');
+        assert(is.equal('test for a new name of the property', secondChanges.old_value), 'second - old value is wrong');
+        assert(is.equal('original name ;)', secondChanges.new_value), 'second - new value is wrong');
+        assert(is.equal('admin changed name to "original name ;)"', secondChanges.message), 'second - wrong message');
+
+        const thirdChanges = response.body.changes[2];
+        assert(is.equal('admin', thirdChanges.username), 'third - must have username = admin');
+        assert(is.equal('', thirdChanges.old_value), 'third - old value is wrong');
+        assert(is.equal('smileys', thirdChanges.new_value), 'third - new value is wrong');
+        assert(is.equal('admin changed unit to "smileys"', thirdChanges.message), 'third - wrong message');
+
+        const fourthChanges = response.body.changes[3];
+        assert(is.equal('admin', fourthChanges.username), 'fourth - must have username = admin');
+        assert(is.equal('false', fourthChanges.old_value), 'fourth - old value is wrong');
+        assert(is.equal('true', fourthChanges.new_value), 'fourth - new value is wrong');
+        assert(is.equal('admin changed canbenull to "true"', fourthChanges.message), 'fourth - wrong message');
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('check changes rows in database table - must have only 3 rows more', function (done) {
+    requestDB
+      .get('/count/changes/' + global.changesCnt)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        global.changesCnt += 3;
+        assert(is.equal(global.changesCnt, response.body.count), 'have ' + response.body.count + ' instead ' + global.changesCnt);
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.body);
+        }
+        return done();
+      });
+  });
+});

--- a/tests/RESTAPI/22_changeslogs/1_properties/4_softdelete_property.js
+++ b/tests/RESTAPI/22_changeslogs/1_properties/4_softdelete_property.js
@@ -1,0 +1,127 @@
+const supertest = require('supertest');
+const assert = require('assert');
+const is = require('is_js');
+
+const request = supertest('http://127.0.0.1/fusionsuite/backend');
+const requestDB = supertest('http://127.0.0.1:8012');
+
+describe('changes | properties | soft delete property', function () {
+  it('soft delete a property', function (done) {
+    request
+      .delete('/v1/config/properties/' + global.propertyId)
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('get the property and check if changes has 5 entries', function (done) {
+    request
+      .get('/v1/config/properties/' + global.propertyId)
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.not.empty(response.body));
+        assert(is.equal('original name ;)', response.body.name));
+        assert(is.propertyDefined(response.body, 'changes'));
+        assert(is.equal(5, response.body.changes.length), 'must have 5 changes');
+
+        const lastChanges = response.body.changes[4];
+        assert(is.equal('admin', lastChanges.username), 'fifth - must have username = admin');
+        assert(is.equal('', lastChanges.old_value), 'fifth - old value is wrong');
+        assert(is.equal('soft delete', lastChanges.new_value), 'fifth - new value is wrong');
+        assert(is.equal('admin soft deleted this item', lastChanges.message), 'fifth - wrong message');
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('check changes rows in database table when soft delete - must have only 1 rows more', function (done) {
+    requestDB
+      .get('/count/changes/' + global.changesCnt)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        global.changesCnt += 1;
+        assert(is.equal(global.changesCnt, response.body.count), 'have ' + response.body.count + ' instead ' + global.changesCnt);
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.body);
+        }
+        return done();
+      });
+  });
+
+  it('restore a soft delete property', function (done) {
+    request
+      .patch('/v1/config/properties/' + global.propertyId)
+      .send({})
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('get the property and check if changes has 6 entries', function (done) {
+    request
+      .get('/v1/config/properties/' + global.propertyId)
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.not.empty(response.body));
+        assert(is.equal('original name ;)', response.body.name));
+        assert(is.propertyDefined(response.body, 'changes'));
+        assert(is.equal(6, response.body.changes.length), 'must have 6 changes');
+
+        const lastChanges = response.body.changes[5];
+        assert(is.equal('admin', lastChanges.username), 'sixth - must have username = admin');
+        assert(is.equal('', lastChanges.old_value), 'sixth - old value is wrong');
+        assert(is.equal('restored', lastChanges.new_value), 'sixth - new value is wrong');
+        assert(is.equal('admin restored this item', lastChanges.message), 'sixth - wrong message');
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('check changes rows in database table when restore - must have only 1 rows more', function (done) {
+    requestDB
+      .get('/count/changes/' + global.changesCnt)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        global.changesCnt += 1;
+        assert(is.equal(global.changesCnt, response.body.count), 'have ' + response.body.count + ' instead ' + global.changesCnt);
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.body);
+        }
+        return done();
+      });
+  });
+});

--- a/tests/RESTAPI/22_changeslogs/1_properties/9_delete_property.js
+++ b/tests/RESTAPI/22_changeslogs/1_properties/9_delete_property.js
@@ -1,0 +1,86 @@
+const supertest = require('supertest');
+const assert = require('assert');
+const is = require('is_js');
+
+const request = supertest('http://127.0.0.1/fusionsuite/backend');
+const requestDB = supertest('http://127.0.0.1:8012');
+
+describe('changes | properties | delete the property', function () {
+  it('soft delete a property', function (done) {
+    request
+      .delete('/v1/config/properties/' + global.propertyId)
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('check changes rows in database table when soft delete - must have only 1 rows more', function (done) {
+    requestDB
+      .get('/count/changes/' + global.changesCnt)
+      .expect(200)
+      .expect(function (response) {
+        global.changesCnt += 1;
+        assert(is.equal(global.changesCnt, response.body.count), 'have ' + response.body.count + ' instead ' + global.changesCnt);
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.body);
+        }
+        return done();
+      });
+  });
+
+  it('hard delete a property', function (done) {
+    request
+      .delete('/v1/config/properties/' + global.propertyId)
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('check changes rows in database table when hard delete - must have only 1 rows more', function (done) {
+    requestDB
+      .get('/count/changes/' + global.changesCnt)
+      .expect(200)
+      .expect(function (response) {
+        global.changesCnt += 1;
+        assert(is.equal(global.changesCnt, response.body.count), 'have ' + response.body.count + ' instead ' + global.changesCnt);
+
+        // test deleted changes row
+        assert(is.equal(1, response.body.rows.length), 'wrong number of changes');
+        assert(is.equal('admin deleted this item', response.body.rows[0].message), 'wrong message');
+        // replace dates to be easier to compare
+        response.body.rows[0].old_value = response.body.rows[0].old_value.replace(/("20\d{2}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})/g, '"**date**');
+        response.body.rows[0].old_value = response.body.rows[0].old_value.replace(/("20\d{2}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.000000Z)/g, '"**date**');
+
+        assert(
+          is.equal(
+            '{"id":' + global.propertyId + ',"name":"original name ;)","internalname":"testforstring","sub_organization":false,"valuetype":"string","regexformat":"","unit":"smileys","description":"Test of the type string","created_at":"**date**","updated_at":"**date**","deleted_at":"**date**","created_by":{"id":2,"name":"admin","first_name":"Steve","last_name":"Rogers"},"updated_by":{"id":2,"name":"admin","first_name":"Steve","last_name":"Rogers"},"deleted_by":{"id":2,"name":"admin","first_name":"Steve","last_name":"Rogers"},"canbenull":true,"setcurrentdate":null,"listvalues":[],"default":"default value","organization":{"id":1,"name":"My organization"}}',
+            response.body.rows[0].old_value,
+          ),
+          'old value is wrong ' + response.body.rows[0].old_value,
+        );
+        assert(is.equal('hard delete', response.body.rows[0].new_value), 'new value is wrong');
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.body);
+        }
+        return done();
+      });
+  });
+});

--- a/tests/RESTAPI/22_changeslogs/2_type/1_create_type.js
+++ b/tests/RESTAPI/22_changeslogs/2_type/1_create_type.js
@@ -1,0 +1,162 @@
+const supertest = require('supertest');
+const validator = require('validator');
+const assert = require('assert');
+const is = require('is_js');
+
+const request = supertest('http://127.0.0.1/fusionsuite/backend');
+const requestDB = supertest('http://127.0.0.1:8012');
+
+describe('changes | types | create a type', function () {
+  it('initial number of changes rows in database table', function (done) {
+    requestDB
+      .get('/count/changes')
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        global.changesCnt = response.body.count;
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.body);
+        }
+        return done();
+      });
+  });
+
+  it('create a new type', function (done) {
+    request
+      .post('/v1/config/types')
+      .send(
+        {
+          name: 'Type for changes',
+        })
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.propertyCount(response.body, 1));
+        assert(is.integer(response.body.id));
+        assert(validator.matches('' + response.body.id, /^\d+$/));
+        global.typeId = response.body.id;
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('get the type and check if changes empty', function (done) {
+    request
+      .get('/v1/config/types/' + global.typeId)
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.not.empty(response.body));
+        assert(is.equal('Type for changes', response.body.name));
+        assert(is.propertyDefined(response.body, 'changes'));
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('check changes rows in database table when add first property - must not have more changes', function (done) {
+    requestDB
+      .get('/count/changes/' + global.changesCnt)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.equal(global.changesCnt, response.body.count));
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.body);
+        }
+        return done();
+      });
+  });
+
+  it('Attach the property "First name" to the type', function (done) {
+    request
+      .post('/v1/config/types/' + global.typeId.toString() + '/property/1')
+      .send()
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {})
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('check changes rows in database table - must have only 1 rows more', function (done) {
+    requestDB
+      .get('/count/changes/' + global.changesCnt)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        global.changesCnt += 1;
+        assert(is.equal(global.changesCnt, response.body.count), 'have ' + response.body.count + ' instead ' + global.changesCnt);
+        assert(is.equal('admin added the property "First name"', response.body.rows[0].message), 'wrong message');
+
+        assert(is.null(response.body.rows[0].old_value), 'old value is wrong ' + response.body.rows[0].old_value);
+        assert(is.equal('{"id":1,"name":"First name"}', response.body.rows[0].new_value), 'new value is wrong, must be: ' + response.body.rows[0].new_value);
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.body);
+        }
+        return done();
+      });
+  });
+
+  it('Attach the property "Last name" to the type', function (done) {
+    request
+      .post('/v1/config/types/' + global.typeId.toString() + '/property/2')
+      .send()
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {})
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('check changes rows in database table when add the second property - must have only 1 rows more', function (done) {
+    requestDB
+      .get('/count/changes/' + global.changesCnt)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        global.changesCnt += 1;
+        assert(is.equal(global.changesCnt, response.body.count), 'have ' + response.body.count + ' instead ' + global.changesCnt);
+        assert(is.equal('admin added the property "Last name"', response.body.rows[0].message), 'wrong message');
+
+        assert(is.null(response.body.rows[0].old_value), 'old value is wrong ' + response.body.rows[0].old_value);
+        assert(is.equal('{"id":2,"name":"Last name"}', response.body.rows[0].new_value), 'new value is wrong, must be: ' + response.body.rows[0].new_value);
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.body);
+        }
+        return done();
+      });
+  });
+});

--- a/tests/RESTAPI/22_changeslogs/2_type/2_getall_types.js
+++ b/tests/RESTAPI/22_changeslogs/2_type/2_getall_types.js
@@ -1,0 +1,29 @@
+const supertest = require('supertest');
+const assert = require('assert');
+const is = require('is_js');
+
+const request = supertest('http://127.0.0.1/fusionsuite/backend');
+
+describe('changes | types | get all types', function () {
+  it('get all types and check changes key not exists', function (done) {
+    request
+      .get('/v1/config/types')
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.array(response.body));
+        assert(is.above(response.body.length, 2));
+
+        const firstType = response.body[0];
+        assert(is.not.propertyDefined(firstType, 'changes'));
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+});

--- a/tests/RESTAPI/22_changeslogs/2_type/3_update_type.js
+++ b/tests/RESTAPI/22_changeslogs/2_type/3_update_type.js
@@ -1,0 +1,70 @@
+const supertest = require('supertest');
+const assert = require('assert');
+const is = require('is_js');
+
+const request = supertest('http://127.0.0.1/fusionsuite/backend');
+const requestDB = supertest('http://127.0.0.1:8012');
+
+describe('changes | types | update a type', function () {
+  it('Update name of the type', function (done) {
+    request
+      .patch('/v1/config/types/' + global.typeId)
+      .send(
+        {
+          name: 'test for a new name of the type',
+        })
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('get the type and check if changes has 3 entries', function (done) {
+    request
+      .get('/v1/config/types/' + global.typeId)
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.not.empty(response.body));
+        assert(is.equal('test for a new name of the type', response.body.name));
+        assert(is.propertyDefined(response.body, 'changes'));
+        assert(is.equal(3, response.body.changes.length), 'must have 3 changes');
+        const firstChanges = response.body.changes[2];
+        assert(is.equal('admin', firstChanges.username), 'must have username = admin');
+        assert(is.equal('Type for changes', firstChanges.old_value), 'old value is wrong');
+        assert(is.equal('test for a new name of the type', firstChanges.new_value), 'new value is wrong');
+        assert(is.equal('admin changed name to "test for a new name of the type"', firstChanges.message), 'wrong message');
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('check changes rows in database table - must have only 1 rows more', function (done) {
+    requestDB
+      .get('/count/changes/' + global.changesCnt)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        global.changesCnt += 1;
+        assert(is.equal(global.changesCnt, response.body.count), 'have ' + response.body.count + ' instead ' + global.changesCnt);
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.body);
+        }
+        return done();
+      });
+  });
+});

--- a/tests/RESTAPI/22_changeslogs/2_type/4_softdelete_property.js
+++ b/tests/RESTAPI/22_changeslogs/2_type/4_softdelete_property.js
@@ -1,0 +1,127 @@
+const supertest = require('supertest');
+const assert = require('assert');
+const is = require('is_js');
+
+const request = supertest('http://127.0.0.1/fusionsuite/backend');
+const requestDB = supertest('http://127.0.0.1:8012');
+
+describe('changes | types | soft delete type', function () {
+  it('soft delete a type', function (done) {
+    request
+      .delete('/v1/config/types/' + global.typeId)
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('get the type and check if changes has 4 entries', function (done) {
+    request
+      .get('/v1/config/types/' + global.typeId)
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.not.empty(response.body));
+        assert(is.equal('test for a new name of the type', response.body.name));
+        assert(is.propertyDefined(response.body, 'changes'));
+        assert(is.equal(4, response.body.changes.length), 'must have 4 changes');
+
+        const lastChanges = response.body.changes[3];
+        assert(is.equal('admin', lastChanges.username), 'fifth - must have username = admin');
+        assert(is.equal('', lastChanges.old_value), 'fifth - old value is wrong');
+        assert(is.equal('soft delete', lastChanges.new_value), 'fifth - new value is wrong');
+        assert(is.equal('admin soft deleted this item', lastChanges.message), 'fifth - wrong message');
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('check changes rows in database table when soft delete - must have only 1 rows more', function (done) {
+    requestDB
+      .get('/count/changes/' + global.changesCnt)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        global.changesCnt += 1;
+        assert(is.equal(global.changesCnt, response.body.count), 'have ' + response.body.count + ' instead ' + global.changesCnt);
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.body);
+        }
+        return done();
+      });
+  });
+
+  it('restore a soft delete type', function (done) {
+    request
+      .patch('/v1/config/types/' + global.typeId)
+      .send({})
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('get the type and check if changes has 5 entries', function (done) {
+    request
+      .get('/v1/config/types/' + global.typeId)
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.not.empty(response.body));
+        assert(is.equal('test for a new name of the type', response.body.name));
+        assert(is.propertyDefined(response.body, 'changes'));
+        assert(is.equal(5, response.body.changes.length), 'must have 5 changes');
+
+        const lastChanges = response.body.changes[4];
+        assert(is.equal('admin', lastChanges.username), 'sixth - must have username = admin');
+        assert(is.equal('', lastChanges.old_value), 'sixth - old value is wrong');
+        assert(is.equal('restored', lastChanges.new_value), 'sixth - new value is wrong');
+        assert(is.equal('admin restored this item', lastChanges.message), 'sixth - wrong message');
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('check changes rows in database table when restore - must have only 1 rows more', function (done) {
+    requestDB
+      .get('/count/changes/' + global.changesCnt)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        global.changesCnt += 1;
+        assert(is.equal(global.changesCnt, response.body.count), 'have ' + response.body.count + ' instead ' + global.changesCnt);
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.body);
+        }
+        return done();
+      });
+  });
+});

--- a/tests/RESTAPI/22_changeslogs/2_type/9_delete_type.js
+++ b/tests/RESTAPI/22_changeslogs/2_type/9_delete_type.js
@@ -1,0 +1,97 @@
+const supertest = require('supertest');
+const assert = require('assert');
+const is = require('is_js');
+
+const request = supertest('http://127.0.0.1/fusionsuite/backend');
+const requestDB = supertest('http://127.0.0.1:8012');
+
+describe('changes | types | delete the type', function () {
+  it('soft delete a type', function (done) {
+    request
+      .delete('/v1/config/types/' + global.typeId)
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('check changes rows in database table - must have only 1 rows more', function (done) {
+    requestDB
+      .get('/count/changes/' + global.changesCnt)
+      .expect(200)
+      .expect(function (response) {
+        global.changesCnt += 1;
+        assert(is.equal(global.changesCnt, response.body.count), 'have ' + response.body.count + ' instead ' + global.changesCnt);
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.body);
+        }
+        return done();
+      });
+  });
+
+  it('hard delete a type', function (done) {
+    request
+      .delete('/v1/config/types/' + global.typeId)
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('check changes rows in database table - must have only 3 rows more', function (done) {
+    requestDB
+      .get('/count/changes/' + global.changesCnt)
+      .expect(200)
+      .expect(function (response) {
+        global.changesCnt += 3;
+        assert(is.equal(global.changesCnt, response.body.count), 'have ' + response.body.count + ' instead ' + global.changesCnt);
+        assert(is.equal(3, response.body.rows.length), 'wrong number of changes');
+        // test deleted the property "First name"
+        let row = response.body.rows[0];
+        assert(is.equal('admin deleted the property "First name"', row.message), '(0) wrong message');
+        assert(is.equal('{"id":1,"name":"First name"}', row.old_value), '(0) old value is wrong, must be: ' + row.old_value);
+        assert(is.null(row.new_value), '(0) old value is wrong ' + row.new_value);
+
+        // test deleted the second property "Last name"
+        row = response.body.rows[1];
+        assert(is.equal('admin deleted the property "Last name"', row.message), '(1) wrong message');
+        assert(is.equal('{"id":2,"name":"Last name"}', row.old_value), '(1) old value is wrong, must be: ' + row.old_value);
+        assert(is.null(row.new_value), '(1) old value is wrong ' + row.new_value);
+
+        // test deleted changes row
+        row = response.body.rows[2];
+        assert(is.equal('admin deleted this item', row.message), '(2) wrong message');
+        // replace dates to be easier to compare
+        row.old_value = row.old_value.replace(/("20\d{2}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})/g, '"**date**');
+        row.old_value = row.old_value.replace(/("20\d{2}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.000000Z)/g, '"**date**');
+        assert(
+          is.equal(
+            '{"id":' + global.typeId + ',"name":"test for a new name of the type","internalname":"typeforchanges","sub_organization":false,"modeling":"logical","tree":false,"allowtreemultipleroots":false,"unique_name":false,"created_at":"**date**","updated_at":"**date**","deleted_at":"**date**","created_by":{"id":2,"name":"admin","first_name":"Steve","last_name":"Rogers"},"updated_by":{"id":2,"name":"admin","first_name":"Steve","last_name":"Rogers"},"deleted_by":{"id":2,"name":"admin","first_name":"Steve","last_name":"Rogers"},"properties":[{"id":1,"name":"First name","internalname":"userfirstname","valuetype":"string","regexformat":null,"unit":null,"description":null,"canbenull":true,"setcurrentdate":null,"listvalues":[],"default":""},{"id":2,"name":"Last name","internalname":"userlastname","valuetype":"string","regexformat":null,"unit":null,"description":null,"canbenull":true,"setcurrentdate":null,"listvalues":[],"default":""}],"propertygroups":[],"organization":{"id":1,"name":"My organization"}}',
+            row.old_value,
+          ),
+          '(2) old value is wrong ' + row.old_value,
+        );
+        assert(is.equal('hard delete', row.new_value), '(2) new value is wrong');
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.body);
+        }
+        return done();
+      });
+  });
+});

--- a/tests/RESTAPI/22_changeslogs/3_item/01_prepare_type.js
+++ b/tests/RESTAPI/22_changeslogs/3_item/01_prepare_type.js
@@ -1,0 +1,578 @@
+const supertest = require('supertest');
+const validator = require('validator');
+const assert = require('assert');
+const is = require('is_js');
+
+const request = supertest('http://127.0.0.1/fusionsuite/backend');
+const requestDB = supertest('http://127.0.0.1:8012');
+
+global.properties = {
+  boolean: 0,
+  date: 0,
+  datetime: 0,
+  decimal: 0,
+  integer: 0,
+  itemlink: 0,
+  itemlinks: 0,
+  list: 0,
+  number: 0,
+  propertylink: 0,
+  string: 0,
+  text: 0,
+  time: 0,
+  typelink: 0,
+  typelinks: 0,
+};
+
+global.changesEntries = 0;
+
+describe('changes | items | prepare type and properties', function () {
+  it('initial number of changes rows in database table', function (done) {
+    requestDB
+      .get('/count/changes')
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        global.changesCnt = response.body.count;
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.body);
+        }
+        return done();
+      });
+  });
+
+  it('create a new type', function (done) {
+    request
+      .post('/v1/config/types')
+      .send({
+        name: 'type for items and properties changes',
+      })
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.propertyCount(response.body, 1));
+        assert(is.integer(response.body.id));
+        assert(validator.matches('' + response.body.id, /^\d+$/));
+        global.typeId = response.body.id;
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('check changes rows in database table - must not have more changes', function (done) {
+    requestDB
+      .get('/count/changes/' + global.changesCnt)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.equal(global.changesCnt, response.body.count));
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.body);
+        }
+        return done();
+      });
+  });
+
+  // create a property on all different valuetype
+  it('create a new boolean property', function (done) {
+    request
+      .post('/v1/config/properties')
+      .send({
+        name: 'property with type boolean',
+        internalname: 'testforboolean',
+        valuetype: 'boolean',
+        listvalues: [],
+        default: true,
+      })
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.propertyCount(response.body, 1));
+        assert(is.integer(response.body.id));
+        assert(validator.matches('' + response.body.id, /^\d+$/));
+        global.propertyBooleanId = response.body.id;
+        global.properties.boolean = response.body.id;
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('create a new date property', function (done) {
+    request
+      .post('/v1/config/properties')
+      .send({
+        name: 'property with type date',
+        internalname: 'testfordate',
+        valuetype: 'date',
+        listvalues: [],
+        default: '2022-11-11',
+      })
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.propertyCount(response.body, 1));
+        assert(is.integer(response.body.id));
+        assert(validator.matches('' + response.body.id, /^\d+$/));
+        global.propertyDateId = response.body.id;
+        global.properties.date = response.body.id;
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('create a new datetime property', function (done) {
+    request
+      .post('/v1/config/properties')
+      .send({
+        name: 'property with type datetime',
+        internalname: 'testfordatetime',
+        valuetype: 'datetime',
+        listvalues: [],
+        default: '2022-11-11 21:58:16',
+      })
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.propertyCount(response.body, 1));
+        assert(is.integer(response.body.id));
+        assert(validator.matches('' + response.body.id, /^\d+$/));
+        global.propertyDatetimeId = response.body.id;
+        global.properties.datetime = response.body.id;
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('create a new decimal property', function (done) {
+    request
+      .post('/v1/config/properties')
+      .send({
+        name: 'property with type decimal',
+        internalname: 'testfordecimal',
+        valuetype: 'decimal',
+        listvalues: [],
+        default: 40.56,
+      })
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.propertyCount(response.body, 1));
+        assert(is.integer(response.body.id));
+        assert(validator.matches('' + response.body.id, /^\d+$/));
+        global.propertyDecimalId = response.body.id;
+        global.properties.decimal = response.body.id;
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('create a new integer property', function (done) {
+    request
+      .post('/v1/config/properties')
+      .send({
+        name: 'property with type integer',
+        internalname: 'testforinteger',
+        valuetype: 'integer',
+        listvalues: [],
+        default: -35005,
+      })
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.propertyCount(response.body, 1));
+        assert(is.integer(response.body.id));
+        assert(validator.matches('' + response.body.id, /^\d+$/));
+        global.propertyIntegerId = response.body.id;
+        global.properties.integer = response.body.id;
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('create a new itemlink property', function (done) {
+    request
+      .post('/v1/config/properties')
+      .send({
+        name: 'property with type itemlink',
+        internalname: 'testforitemlink',
+        valuetype: 'itemlink',
+        listvalues: ['users'],
+        default: 2,
+      })
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.propertyCount(response.body, 1));
+        assert(is.integer(response.body.id));
+        assert(validator.matches('' + response.body.id, /^\d+$/));
+        global.propertyItemlinklId = response.body.id;
+        global.properties.itemlink = response.body.id;
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('create a new itemlinks property', function (done) {
+    request
+      .post('/v1/config/properties')
+      .send({
+        name: 'property with type itemlinks',
+        internalname: 'testforitemlinks',
+        valuetype: 'itemlinks',
+        listvalues: ['users'],
+        default: [2],
+      })
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.propertyCount(response.body, 1));
+        assert(is.integer(response.body.id));
+        assert(validator.matches('' + response.body.id, /^\d+$/));
+        global.propertyItemlinksId = response.body.id;
+        global.properties.itemlinks = response.body.id;
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('create a new list property', function (done) {
+    request
+      .post('/v1/config/properties')
+      .send({
+        name: 'property with type list',
+        internalname: 'testforlist',
+        valuetype: 'list',
+        listvalues: ['test 1', 'test 2', 'test 3'],
+        default: 'test 1',
+      })
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.propertyCount(response.body, 1));
+        assert(is.integer(response.body.id));
+        assert(validator.matches('' + response.body.id, /^\d+$/));
+        global.propertyListId = response.body.id;
+        global.properties.list = response.body.id;
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('create a new number property', function (done) {
+    request
+      .post('/v1/config/properties')
+      .send({
+        name: 'property with type number',
+        internalname: 'testfornumber',
+        valuetype: 'number',
+        listvalues: [],
+        default: 42,
+      })
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.propertyCount(response.body, 1));
+        assert(is.integer(response.body.id));
+        assert(validator.matches('' + response.body.id, /^\d+$/));
+        global.propertyNumberId = response.body.id;
+        global.properties.number = response.body.id;
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('create a new propertylink property', function (done) {
+    request
+      .post('/v1/config/properties')
+      .send({
+        name: 'property with type propertylink',
+        internalname: 'testforpropertylink',
+        valuetype: 'propertylink',
+        listvalues: [],
+        default: 1,
+      })
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.propertyCount(response.body, 1));
+        assert(is.integer(response.body.id));
+        assert(validator.matches('' + response.body.id, /^\d+$/));
+        global.propertyPropertylinkId = response.body.id;
+        global.properties.propertylink = response.body.id;
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('create a new string property', function (done) {
+    request
+      .post('/v1/config/properties')
+      .send({
+        name: 'property with type string',
+        internalname: 'testforstring',
+        valuetype: 'string',
+        listvalues: [],
+        default: 'my default value',
+      })
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.propertyCount(response.body, 1));
+        assert(is.integer(response.body.id));
+        assert(validator.matches('' + response.body.id, /^\d+$/));
+        global.propertyStringId = response.body.id;
+        global.properties.string = response.body.id;
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('create a new text property', function (done) {
+    request
+      .post('/v1/config/properties')
+      .send({
+        name: 'property with type text',
+        internalname: 'testfortext',
+        valuetype: 'text',
+        listvalues: [],
+        default: 'my default value\nMultiple lines',
+      })
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.propertyCount(response.body, 1));
+        assert(is.integer(response.body.id));
+        assert(validator.matches('' + response.body.id, /^\d+$/));
+        global.propertyTextId = response.body.id;
+        global.properties.text = response.body.id;
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('create a new time property', function (done) {
+    request
+      .post('/v1/config/properties')
+      .send({
+        name: 'property with type time',
+        internalname: 'testfortime',
+        valuetype: 'time',
+        listvalues: [],
+        default: '07:14:58',
+      })
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.propertyCount(response.body, 1));
+        assert(is.integer(response.body.id));
+        assert(validator.matches('' + response.body.id, /^\d+$/));
+        global.propertyTimeId = response.body.id;
+        global.properties.time = response.body.id;
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('create a new typelink property', function (done) {
+    request
+      .post('/v1/config/properties')
+      .send({
+        name: 'property with type typelink',
+        internalname: 'testfortypelink',
+        valuetype: 'typelink',
+        listvalues: [],
+        default: 1,
+      })
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.propertyCount(response.body, 1));
+        assert(is.integer(response.body.id));
+        assert(validator.matches('' + response.body.id, /^\d+$/));
+        global.propertyTypelinklId = response.body.id;
+        global.properties.typelink = response.body.id;
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('create a new typelinks property', function (done) {
+    request
+      .post('/v1/config/properties')
+      .send({
+        name: 'property with type typelinks',
+        internalname: 'testfortypelinks',
+        valuetype: 'typelinks',
+        listvalues: [],
+        default: [1],
+      })
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.propertyCount(response.body, 1));
+        assert(is.integer(response.body.id));
+        assert(validator.matches('' + response.body.id, /^\d+$/));
+        global.propertyTypelinksId = response.body.id;
+        global.properties.typelinks = response.body.id;
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('re-initial number of changes rows in database table', function (done) {
+    requestDB
+      .get('/count/changes')
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        global.changesCnt = response.body.count;
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.body);
+        }
+        return done();
+      });
+  });
+
+  // attach properties to the type
+  // eslint-disable-next-line mocha/no-setup-in-describe
+  for (const propertyType in global.properties) {
+    it('Attach a property to the type ' + propertyType, function (done) {
+      request
+        .post('/v1/config/types/' + global.typeId.toString() + '/property/' + global.properties[propertyType].toString())
+        .send()
+        .set('Accept', 'application/json')
+        .set('Authorization', 'Bearer ' + global.token)
+        .expect(200)
+        .expect('Content-Type', /json/)
+        .expect(function (response) {})
+        .end(function (err, response) {
+          if (err) {
+            return done(err + ' | Response: ' + response.text);
+          }
+          return done();
+        });
+    });
+
+    it('check changes rows in database table - must have only 1 rows more', function (done) {
+      requestDB
+        .get('/count/changes/' + global.changesCnt)
+        .expect(200)
+        .expect('Content-Type', /json/)
+        .expect(function (response) {
+          global.changesCnt += 1;
+          assert(is.equal(global.changesCnt, response.body.count), 'have ' + response.body.count + ' instead ' + global.changesCnt);
+          assert(is.equal('admin added the property "property with type ' + propertyType + '"', response.body.rows[0].message), 'wrong message');
+          assert(is.null(response.body.rows[0].old_value), 'old value is wrong ' + response.body.rows[0].old_value);
+          assert(is.equal('{"id":' + global.properties[propertyType] + ',"name":"property with type ' + propertyType + '"}', response.body.rows[0].new_value), 'new value is wrong, must be: ' + response.body.rows[0].new_value);
+        })
+        .end(function (err, response) {
+          if (err) {
+            return done(err + ' | Response: ' + response.body);
+          }
+          return done();
+        });
+    });
+  }
+});

--- a/tests/RESTAPI/22_changeslogs/3_item/02_create_item.js
+++ b/tests/RESTAPI/22_changeslogs/3_item/02_create_item.js
@@ -1,0 +1,70 @@
+const supertest = require('supertest');
+const validator = require('validator');
+const assert = require('assert');
+const is = require('is_js');
+
+const request = supertest('http://127.0.0.1/fusionsuite/backend');
+const requestDB = supertest('http://127.0.0.1:8012');
+
+describe('changes | items | create an item', function () {
+  it('create a new item', function (done) {
+    request
+      .post('/v1/items')
+      .send({
+        name: 'laptop xxx5xx',
+        type_id: global.typeId,
+      })
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.propertyCount(response.body, 2));
+        assert(is.integer(response.body.id));
+        assert(validator.matches('' + response.body.id, /^\d+$/));
+        global.itemId = response.body.id;
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('get the item and check if changes empty', function (done) {
+    request
+      .get('/v1/items/' + global.itemId)
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.not.empty(response.body));
+        assert(is.equal('laptop xxx5xx', response.body.name));
+        assert(is.propertyDefined(response.body, 'changes'));
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('check changes rows in database table - must not have more changes', function (done) {
+    requestDB
+      .get('/count/changes/' + global.changesCnt)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.equal(global.changesCnt, response.body.count));
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.body);
+        }
+        return done();
+      });
+  });
+});

--- a/tests/RESTAPI/22_changeslogs/3_item/03_getall_item.js
+++ b/tests/RESTAPI/22_changeslogs/3_item/03_getall_item.js
@@ -1,0 +1,29 @@
+const supertest = require('supertest');
+const assert = require('assert');
+const is = require('is_js');
+
+const request = supertest('http://127.0.0.1/fusionsuite/backend');
+
+describe('changes | items | get all items', function () {
+  it('get all items and check changes key not exists', function (done) {
+    request
+      .get('/v1/items/type/' + global.typeId)
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.array(response.body));
+        assert(is.above(response.body.length, 0));
+
+        const firstItem = response.body[0];
+        assert(is.not.propertyDefined(firstItem, 'changes'));
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+});

--- a/tests/RESTAPI/22_changeslogs/3_item/04_update_item.js
+++ b/tests/RESTAPI/22_changeslogs/3_item/04_update_item.js
@@ -1,0 +1,70 @@
+const supertest = require('supertest');
+const assert = require('assert');
+const is = require('is_js');
+
+const request = supertest('http://127.0.0.1/fusionsuite/backend');
+const requestDB = supertest('http://127.0.0.1:8012');
+
+describe('changes | items | update an item', function () {
+  it('Update name of the item', function (done) {
+    request
+      .patch('/v1/items/' + global.itemId)
+      .send(
+        {
+          name: 'laptop yyy6yy',
+        })
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('get the item and check if changes has one entry', function (done) {
+    request
+      .get('/v1/items/' + global.itemId)
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.not.empty(response.body));
+        assert(is.equal('laptop yyy6yy', response.body.name));
+        assert(is.propertyDefined(response.body, 'changes'));
+        assert(is.equal(1, response.body.changes.length), 'must have 1 changes');
+        const firstChanges = response.body.changes[0];
+        assert(is.equal('admin', firstChanges.username), 'must have username = admin');
+        assert(is.equal('laptop xxx5xx', firstChanges.old_value), 'old value is wrong');
+        assert(is.equal('laptop yyy6yy', firstChanges.new_value), 'new value is wrong');
+        assert(is.equal('admin changed name to "laptop yyy6yy"', firstChanges.message), 'wrong message');
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('check changes rows in database table - must have only 1 rows more', function (done) {
+    requestDB
+      .get('/count/changes/' + global.changesCnt)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        global.changesCnt += 1;
+        assert(is.equal(global.changesCnt, response.body.count), 'have ' + response.body.count + ' instead ' + global.changesCnt);
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.body);
+        }
+        return done();
+      });
+  });
+});

--- a/tests/RESTAPI/22_changeslogs/3_item/05_softdelete_item.js
+++ b/tests/RESTAPI/22_changeslogs/3_item/05_softdelete_item.js
@@ -1,0 +1,128 @@
+const supertest = require('supertest');
+const assert = require('assert');
+const is = require('is_js');
+
+const request = supertest('http://127.0.0.1/fusionsuite/backend');
+const requestDB = supertest('http://127.0.0.1:8012');
+
+describe('changes | items | soft delete item', function () {
+  it('soft delete an item', function (done) {
+    request
+      .delete('/v1/items/' + global.itemId)
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('get the item and check if changes has 2 entries', function (done) {
+    request
+      .get('/v1/items/' + global.itemId)
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.not.empty(response.body));
+        assert(is.equal('laptop yyy6yy', response.body.name));
+        assert(is.propertyDefined(response.body, 'changes'));
+        assert(is.equal(2, response.body.changes.length), 'must have 2 changes');
+
+        const lastChanges = response.body.changes[1];
+        assert(is.equal('admin', lastChanges.username), 'fifth - must have username = admin');
+        assert(is.equal('', lastChanges.old_value), 'fifth - old value is wrong');
+        assert(is.equal('soft delete', lastChanges.new_value), 'fifth - new value is wrong');
+        assert(is.equal('admin soft deleted this item', lastChanges.message), 'fifth - wrong message');
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('check changes rows in database table when soft delete - must have only 1 rows more', function (done) {
+    requestDB
+      .get('/count/changes/' + global.changesCnt)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        global.changesCnt += 1;
+        assert(is.equal(global.changesCnt, response.body.count), 'have ' + response.body.count + ' instead ' + global.changesCnt);
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.body);
+        }
+        return done();
+      });
+  });
+
+  it('restore a soft delete item', function (done) {
+    request
+      .patch('/v1/items/' + global.itemId)
+      .send({})
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('get the item and check if changes has 3 entries', function (done) {
+    global.changesEntries = 3;
+    request
+      .get('/v1/items/' + global.itemId)
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.not.empty(response.body));
+        assert(is.equal('laptop yyy6yy', response.body.name));
+        assert(is.propertyDefined(response.body, 'changes'));
+        assert(is.equal(3, response.body.changes.length), 'must have 3 changes');
+
+        const lastChanges = response.body.changes[2];
+        assert(is.equal('admin', lastChanges.username), 'sixth - must have username = admin');
+        assert(is.equal('', lastChanges.old_value), 'sixth - old value is wrong');
+        assert(is.equal('restored', lastChanges.new_value), 'sixth - new value is wrong');
+        assert(is.equal('admin restored this item', lastChanges.message), 'sixth - wrong message');
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('check changes rows in database table when restore - must have only 1 rows more', function (done) {
+    requestDB
+      .get('/count/changes/' + global.changesCnt)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        global.changesCnt += 1;
+        assert(is.equal(global.changesCnt, response.body.count), 'have ' + response.body.count + ' instead ' + global.changesCnt);
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.body);
+        }
+        return done();
+      });
+  });
+});

--- a/tests/RESTAPI/22_changeslogs/3_item/10_update_item_property_boolean.js
+++ b/tests/RESTAPI/22_changeslogs/3_item/10_update_item_property_boolean.js
@@ -1,0 +1,72 @@
+const supertest = require('supertest');
+const assert = require('assert');
+const is = require('is_js');
+
+const request = supertest('http://127.0.0.1/fusionsuite/backend');
+const requestDB = supertest('http://127.0.0.1:8012');
+
+describe('changes | items | update boolean type property', function () {
+  it('Update boolean property of the item', function (done) {
+    request
+      .patch('/v1/items/' + global.itemId + '/property/' + global.properties.boolean)
+      .send(
+        {
+          value: false,
+        })
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('get the item and check if changes has new entry', function (done) {
+    global.changesEntries += 1;
+    request
+      .get('/v1/items/' + global.itemId)
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.not.empty(response.body));
+        assert(is.equal('laptop yyy6yy', response.body.name));
+        assert(is.propertyDefined(response.body, 'changes'));
+        assert(is.equal(global.changesEntries, response.body.changes.length), 'must have ' + global.changesEntries + ' changes');
+
+        const lastChanges = response.body.changes[(global.changesEntries - 1)];
+        assert(is.equal('admin', lastChanges.username), 'must have username = admin');
+        assert(is.equal('true', lastChanges.old_value), 'old value is wrong');
+        assert(is.equal('false', lastChanges.new_value), 'new value is wrong');
+        assert(is.equal('admin changed property with type boolean to "false"', lastChanges.message), 'wrong message');
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('check changes rows in database table when update property - must have only 1 rows more', function (done) {
+    requestDB
+      .get('/count/changes/' + global.changesCnt)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        global.changesCnt += 1;
+        assert(is.equal(global.changesCnt, response.body.count), 'have ' + response.body.count + ' instead ' + global.changesCnt);
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.body);
+        }
+        return done();
+      });
+  });
+});

--- a/tests/RESTAPI/22_changeslogs/3_item/11_update_item_property_date.js
+++ b/tests/RESTAPI/22_changeslogs/3_item/11_update_item_property_date.js
@@ -1,0 +1,72 @@
+const supertest = require('supertest');
+const assert = require('assert');
+const is = require('is_js');
+
+const request = supertest('http://127.0.0.1/fusionsuite/backend');
+const requestDB = supertest('http://127.0.0.1:8012');
+
+describe('changes | items | update date type property', function () {
+  it('Update date property of the item', function (done) {
+    request
+      .patch('/v1/items/' + global.itemId + '/property/' + global.properties.date)
+      .send(
+        {
+          value: '2022-11-01',
+        })
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('get the item and check if changes has new entry', function (done) {
+    global.changesEntries += 1;
+    request
+      .get('/v1/items/' + global.itemId)
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.not.empty(response.body));
+        assert(is.equal('laptop yyy6yy', response.body.name));
+        assert(is.propertyDefined(response.body, 'changes'));
+        assert(is.equal(global.changesEntries, response.body.changes.length), 'must have ' + global.changesEntries + ' changes');
+
+        const lastChanges = response.body.changes[(global.changesEntries - 1)];
+        assert(is.equal('admin', lastChanges.username), 'must have username = admin');
+        assert(is.equal('2022-11-11', lastChanges.old_value), 'old value is wrong');
+        assert(is.equal('2022-11-01', lastChanges.new_value), 'new value is wrong');
+        assert(is.equal('admin changed property with type date to "2022-11-01"', lastChanges.message), 'wrong message');
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('check changes rows in database table when update property - must have only 1 rows more', function (done) {
+    requestDB
+      .get('/count/changes/' + global.changesCnt)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        global.changesCnt += 1;
+        assert(is.equal(global.changesCnt, response.body.count), 'have ' + response.body.count + ' instead ' + global.changesCnt);
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.body);
+        }
+        return done();
+      });
+  });
+});

--- a/tests/RESTAPI/22_changeslogs/3_item/12_update_item_property_datetime.js
+++ b/tests/RESTAPI/22_changeslogs/3_item/12_update_item_property_datetime.js
@@ -1,0 +1,72 @@
+const supertest = require('supertest');
+const assert = require('assert');
+const is = require('is_js');
+
+const request = supertest('http://127.0.0.1/fusionsuite/backend');
+const requestDB = supertest('http://127.0.0.1:8012');
+
+describe('changes | items | update datetime type property', function () {
+  it('Update datetime property of the item', function (done) {
+    request
+      .patch('/v1/items/' + global.itemId + '/property/' + global.properties.datetime)
+      .send(
+        {
+          value: '2022-11-12 08:49:47',
+        })
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('get the item and check if changes has new entry', function (done) {
+    global.changesEntries += 1;
+    request
+      .get('/v1/items/' + global.itemId)
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.not.empty(response.body));
+        assert(is.equal('laptop yyy6yy', response.body.name));
+        assert(is.propertyDefined(response.body, 'changes'));
+        assert(is.equal(global.changesEntries, response.body.changes.length), 'must have ' + global.changesEntries + ' changes');
+
+        const lastChanges = response.body.changes[(global.changesEntries - 1)];
+        assert(is.equal('admin', lastChanges.username), 'must have username = admin');
+        assert(is.equal('2022-11-11 21:58:16', lastChanges.old_value), 'old value is wrong');
+        assert(is.equal('2022-11-12 08:49:47', lastChanges.new_value), 'new value is wrong');
+        assert(is.equal('admin changed property with type datetime to "2022-11-12 08:49:47"', lastChanges.message), 'wrong message');
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('check changes rows in database table when update property - must have only 1 rows more', function (done) {
+    requestDB
+      .get('/count/changes/' + global.changesCnt)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        global.changesCnt += 1;
+        assert(is.equal(global.changesCnt, response.body.count), 'have ' + response.body.count + ' instead ' + global.changesCnt);
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.body);
+        }
+        return done();
+      });
+  });
+});

--- a/tests/RESTAPI/22_changeslogs/3_item/13_update_item_property_decimal.js
+++ b/tests/RESTAPI/22_changeslogs/3_item/13_update_item_property_decimal.js
@@ -1,0 +1,72 @@
+const supertest = require('supertest');
+const assert = require('assert');
+const is = require('is_js');
+
+const request = supertest('http://127.0.0.1/fusionsuite/backend');
+const requestDB = supertest('http://127.0.0.1:8012');
+
+describe('changes | items | update decimal type property', function () {
+  it('Update decimal property of the item', function (done) {
+    request
+      .patch('/v1/items/' + global.itemId + '/property/' + global.properties.decimal)
+      .send(
+        {
+          value: 3.141592,
+        })
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('get the item and check if changes has new entry', function (done) {
+    global.changesEntries += 1;
+    request
+      .get('/v1/items/' + global.itemId)
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.not.empty(response.body));
+        assert(is.equal('laptop yyy6yy', response.body.name));
+        assert(is.propertyDefined(response.body, 'changes'));
+        assert(is.equal(global.changesEntries, response.body.changes.length), 'must have ' + global.changesEntries + ' changes');
+
+        const lastChanges = response.body.changes[(global.changesEntries - 1)];
+        assert(is.equal('admin', lastChanges.username), 'must have username = admin');
+        assert(is.equal('40.56', lastChanges.old_value), 'old value is wrong');
+        assert(is.equal('3.141592', lastChanges.new_value), 'new value is wrong');
+        assert(is.equal('admin changed property with type decimal to "3.141592"', lastChanges.message), 'wrong message');
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('check changes rows in database table when update property - must have only 1 rows more', function (done) {
+    requestDB
+      .get('/count/changes/' + global.changesCnt)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        global.changesCnt += 1;
+        assert(is.equal(global.changesCnt, response.body.count), 'have ' + response.body.count + ' instead ' + global.changesCnt);
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.body);
+        }
+        return done();
+      });
+  });
+});

--- a/tests/RESTAPI/22_changeslogs/3_item/14_update_item_property_integer.js
+++ b/tests/RESTAPI/22_changeslogs/3_item/14_update_item_property_integer.js
@@ -1,0 +1,72 @@
+const supertest = require('supertest');
+const assert = require('assert');
+const is = require('is_js');
+
+const request = supertest('http://127.0.0.1/fusionsuite/backend');
+const requestDB = supertest('http://127.0.0.1:8012');
+
+describe('changes | items | update integer type property', function () {
+  it('Update integer property of the item', function (done) {
+    request
+      .patch('/v1/items/' + global.itemId + '/property/' + global.properties.integer)
+      .send(
+        {
+          value: 42,
+        })
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('get the item and check if changes has new entry', function (done) {
+    global.changesEntries += 1;
+    request
+      .get('/v1/items/' + global.itemId)
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.not.empty(response.body));
+        assert(is.equal('laptop yyy6yy', response.body.name));
+        assert(is.propertyDefined(response.body, 'changes'));
+        assert(is.equal(global.changesEntries, response.body.changes.length), 'must have ' + global.changesEntries + ' changes');
+
+        const lastChanges = response.body.changes[(global.changesEntries - 1)];
+        assert(is.equal('admin', lastChanges.username), 'must have username = admin');
+        assert(is.equal('-35005', lastChanges.old_value), 'old value is wrong');
+        assert(is.equal('42', lastChanges.new_value), 'new value is wrong');
+        assert(is.equal('admin changed property with type integer to "42"', lastChanges.message), 'wrong message');
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('check changes rows in database table when update property - must have only 1 rows more', function (done) {
+    requestDB
+      .get('/count/changes/' + global.changesCnt)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        global.changesCnt += 1;
+        assert(is.equal(global.changesCnt, response.body.count), 'have ' + response.body.count + ' instead ' + global.changesCnt);
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.body);
+        }
+        return done();
+      });
+  });
+});

--- a/tests/RESTAPI/22_changeslogs/3_item/15_update_item_property_itemlink.js
+++ b/tests/RESTAPI/22_changeslogs/3_item/15_update_item_property_itemlink.js
@@ -1,0 +1,72 @@
+const supertest = require('supertest');
+const assert = require('assert');
+const is = require('is_js');
+
+const request = supertest('http://127.0.0.1/fusionsuite/backend');
+const requestDB = supertest('http://127.0.0.1:8012');
+
+describe('changes | items | update itemlink type property', function () {
+  it('Update itemlink property of the item', function (done) {
+    request
+      .patch('/v1/items/' + global.itemId + '/property/' + global.properties.itemlink)
+      .send(
+        {
+          value: 1,
+        })
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('get the item and check if changes has new entry', function (done) {
+    global.changesEntries += 1;
+    request
+      .get('/v1/items/' + global.itemId)
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.not.empty(response.body));
+        assert(is.equal('laptop yyy6yy', response.body.name));
+        assert(is.propertyDefined(response.body, 'changes'));
+        assert(is.equal(global.changesEntries, response.body.changes.length), 'must have ' + global.changesEntries + ' changes');
+
+        const lastChanges = response.body.changes[(global.changesEntries - 1)];
+        assert(is.equal('admin', lastChanges.username), 'must have username = admin');
+        assert(is.equal('{"id":2,"name":"admin"}', lastChanges.old_value), 'old value is wrong');
+        assert(is.equal('{"id":1,"name":"My organization"}', lastChanges.new_value), 'new value is wrong');
+        assert(is.equal('admin changed "property with type itemlink" to "My organization"', lastChanges.message), 'wrong message');
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('check changes rows in database table when update property - must have only 1 rows more', function (done) {
+    requestDB
+      .get('/count/changes/' + global.changesCnt)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        global.changesCnt += 1;
+        assert(is.equal(global.changesCnt, response.body.count), 'have ' + response.body.count + ' instead ' + global.changesCnt);
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.body);
+        }
+        return done();
+      });
+  });
+});

--- a/tests/RESTAPI/22_changeslogs/3_item/16_update_item_property_itemlinks.js
+++ b/tests/RESTAPI/22_changeslogs/3_item/16_update_item_property_itemlinks.js
@@ -1,0 +1,330 @@
+const supertest = require('supertest');
+const assert = require('assert');
+const is = require('is_js');
+
+const request = supertest('http://127.0.0.1/fusionsuite/backend');
+const requestDB = supertest('http://127.0.0.1:8012');
+
+describe('changes | items | update itemlinks type property', function () {
+  it('add an itemlink property of the item', function (done) {
+    request
+      .post('/v1/items/' + global.itemId + '/property/' + global.properties.itemlinks + '/itemlinks')
+      .send(
+        {
+          value: 1,
+        })
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('get the items (after added) and check if changes has new entry', function (done) {
+    global.changesEntries += 1;
+    request
+      .get('/v1/items/' + global.itemId)
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.not.empty(response.body));
+        assert(is.equal('laptop yyy6yy', response.body.name));
+        assert(is.propertyDefined(response.body, 'changes'));
+        assert(is.equal(global.changesEntries, response.body.changes.length), 'must have ' + global.changesEntries + ' changes');
+
+        const lastChanges = response.body.changes[(global.changesEntries - 1)];
+        assert(is.equal('admin', lastChanges.username), 'must have username = admin');
+        assert(is.null(lastChanges.old_value), 'old value is wrong');
+        assert(is.equal('{"id":1,"name":"My organization"}', lastChanges.new_value), 'new value is wrong');
+        assert(is.equal('admin added "My organization" (Organization) to "property with type itemlinks"', lastChanges.message), 'wrong message');
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('check changes rows in database table when add property - must have only 1 rows more', function (done) {
+    requestDB
+      .get('/count/changes/' + global.changesCnt)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        global.changesCnt += 1;
+        assert(is.equal(global.changesCnt, response.body.count), 'have ' + response.body.count + ' instead ' + global.changesCnt);
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.body);
+        }
+        return done();
+      });
+  });
+
+  it('delete an itemlink property of the item', function (done) {
+    request
+      .delete('/v1/items/' + global.itemId + '/property/' + global.properties.itemlinks + '/itemlinks/1')
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('get the items (after deleted) and check if changes has new entry', function (done) {
+    global.changesEntries += 1;
+    request
+      .get('/v1/items/' + global.itemId)
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.not.empty(response.body));
+        assert(is.equal('laptop yyy6yy', response.body.name));
+        assert(is.propertyDefined(response.body, 'changes'));
+        assert(is.equal(global.changesEntries, response.body.changes.length), 'must have ' + global.changesEntries + ' changes');
+
+        const lastChanges = response.body.changes[(global.changesEntries - 1)];
+        assert(is.equal('admin', lastChanges.username), 'must have username = admin');
+        assert(is.equal('{"id":1,"name":"My organization"}', lastChanges.old_value), 'old value is wrong');
+        assert(is.null(lastChanges.new_value), 'new value is wrong');
+        assert(is.equal('admin deleted property "property with type itemlinks" named "My organization"', lastChanges.message), 'wrong message');
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('check changes rows in database table when delete property - must have only 1 rows more', function (done) {
+    requestDB
+      .get('/count/changes/' + global.changesCnt)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        global.changesCnt += 1;
+        assert(is.equal(global.changesCnt, response.body.count), 'have ' + response.body.count + ' instead ' + global.changesCnt);
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.body);
+        }
+        return done();
+      });
+  });
+
+  it('Update itemlinks property of the item to [1, 2]', function (done) {
+    request
+      .patch('/v1/items/' + global.itemId + '/property/' + global.properties.itemlinks)
+      .send(
+        {
+          value: [1, 2],
+        })
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('get the item and check if changes has new entry', function (done) {
+    global.changesEntries += 1;
+    request
+      .get('/v1/items/' + global.itemId)
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.not.empty(response.body));
+        assert(is.equal('laptop yyy6yy', response.body.name));
+        assert(is.propertyDefined(response.body, 'changes'));
+        assert(is.equal(global.changesEntries, response.body.changes.length), 'must have ' + global.changesEntries + ' changes');
+
+        const lastChanges = response.body.changes[(global.changesEntries - 1)];
+        assert(is.equal('admin', lastChanges.username), 'must have username = admin');
+        assert(is.null(lastChanges.old_value), 'old value is wrong');
+        assert(is.equal('{"id":1,"name":"My organization"}', lastChanges.new_value), 'new value is wrong');
+        assert(is.equal('admin added "My organization" (Organization) to "property with type itemlinks"', lastChanges.message), 'wrong message');
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('check changes rows in database table when update to [1, 2] - must have only 1 rows more', function (done) {
+    requestDB
+      .get('/count/changes/' + global.changesCnt)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        global.changesCnt += 1;
+        assert(is.equal(global.changesCnt, response.body.count), 'have ' + response.body.count + ' instead ' + global.changesCnt);
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.body);
+        }
+        return done();
+      });
+  });
+
+  it('Update itemlinks property of the item to [2] (will delete the id 1', function (done) {
+    request
+      .patch('/v1/items/' + global.itemId + '/property/' + global.properties.itemlinks)
+      .send(
+        {
+          value: [2],
+        })
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('get the item and check if changes has new entry after reduced items', function (done) {
+    global.changesEntries += 1;
+    request
+      .get('/v1/items/' + global.itemId)
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.not.empty(response.body));
+        assert(is.equal('laptop yyy6yy', response.body.name));
+        assert(is.propertyDefined(response.body, 'changes'));
+        assert(is.equal(global.changesEntries, response.body.changes.length), 'must have ' + global.changesEntries + ' changes');
+
+        const lastChanges = response.body.changes[(global.changesEntries - 1)];
+        assert(is.equal('admin', lastChanges.username), 'must have username = admin');
+        assert(is.equal('{"id":1,"name":"My organization"}', lastChanges.old_value), 'old value is wrong');
+        assert(is.null(lastChanges.new_value), 'new value is wrong');
+        assert(is.equal('admin deleted property "property with type itemlinks" named "My organization"', lastChanges.message), 'wrong message');
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('check changes rows in database table when update to [2] - must have only 1 rows more', function (done) {
+    requestDB
+      .get('/count/changes/' + global.changesCnt)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        global.changesCnt += 1;
+        assert(is.equal(global.changesCnt, response.body.count), 'have ' + response.body.count + ' instead ' + global.changesCnt);
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.body);
+        }
+        return done();
+      });
+  });
+
+  it('Update itemlinks property of the item to null value', function (done) {
+    request
+      .patch('/v1/items/' + global.itemId + '/property/' + global.properties.itemlinks)
+      .send(
+        {
+          value: null,
+        })
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('get the item and check if changes has 2 new entries after null', function (done) {
+    global.changesEntries += 2;
+    request
+      .get('/v1/items/' + global.itemId)
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.not.empty(response.body));
+        assert(is.equal('laptop yyy6yy', response.body.name));
+        assert(is.propertyDefined(response.body, 'changes'));
+        assert(is.equal(global.changesEntries, response.body.changes.length), 'must have ' + global.changesEntries + ' changes');
+
+        let lastChanges = response.body.changes[(global.changesEntries - 2)];
+        assert(is.equal('admin', lastChanges.username), 'must have username = admin');
+        assert(is.equal('{"id":2,"name":"admin"}', lastChanges.old_value), 'old value is wrong');
+        assert(is.null(lastChanges.new_value), 'new value is wrong');
+        assert(is.equal('admin deleted property "property with type itemlinks" named "admin"', lastChanges.message), 'wrong message');
+
+        lastChanges = response.body.changes[(global.changesEntries - 1)];
+        assert(is.equal('admin', lastChanges.username), 'must have username = admin');
+        assert(is.null(lastChanges.old_value), 'old value is wrong');
+        assert(is.null(lastChanges.new_value), 'new value is wrong');
+        assert(is.equal('admin added null to "property with type itemlinks"', lastChanges.message), 'wrong message');
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('check changes rows in database table when update to null - must have only 2 rows more', function (done) {
+    requestDB
+      .get('/count/changes/' + global.changesCnt)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        global.changesCnt += 2;
+        assert(is.equal(global.changesCnt, response.body.count), 'have ' + response.body.count + ' instead ' + global.changesCnt);
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.body);
+        }
+        return done();
+      });
+  });
+});

--- a/tests/RESTAPI/22_changeslogs/3_item/17_update_item_property_list.js
+++ b/tests/RESTAPI/22_changeslogs/3_item/17_update_item_property_list.js
@@ -1,0 +1,95 @@
+const supertest = require('supertest');
+const assert = require('assert');
+const is = require('is_js');
+
+const request = supertest('http://127.0.0.1/fusionsuite/backend');
+const requestDB = supertest('http://127.0.0.1:8012');
+
+describe('changes | items | update list type property', function () {
+  it('get listvlaues of the property', function (done) {
+    request
+      .get('/v1/config/properties/' + global.properties.list)
+      .send()
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.not.empty(response.body), 'The body must contain something');
+        global.listIds = {};
+        for (const prop of response.body.listvalues) {
+          global.listIds[prop.value] = prop.id;
+        }
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('update list property of the item', function (done) {
+    request
+      .patch('/v1/items/' + global.itemId + '/property/' + global.properties.list)
+      .send(
+        {
+          value: global.listIds['test 2'],
+        })
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('get the item and check if changes has new entry', function (done) {
+    global.changesEntries += 1;
+    request
+      .get('/v1/items/' + global.itemId)
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.not.empty(response.body));
+        assert(is.equal('laptop yyy6yy', response.body.name));
+        assert(is.propertyDefined(response.body, 'changes'));
+        assert(is.equal(global.changesEntries, response.body.changes.length), 'must have ' + global.changesEntries + ' changes');
+
+        const lastChanges = response.body.changes[(global.changesEntries - 1)];
+        assert(is.equal('admin', lastChanges.username), 'must have username = admin');
+        assert(is.equal('test 1', lastChanges.old_value), 'old value is wrong');
+        assert(is.equal('test 2', lastChanges.new_value), 'new value is wrong');
+        assert(is.equal('admin changed property with type list to "test 2"', lastChanges.message), 'wrong message');
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('check changes rows in database table when update property - must have only 1 rows more', function (done) {
+    requestDB
+      .get('/count/changes/' + global.changesCnt)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        global.changesCnt += 1;
+        assert(is.equal(global.changesCnt, response.body.count), 'have ' + response.body.count + ' instead ' + global.changesCnt);
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.body);
+        }
+        return done();
+      });
+  });
+});

--- a/tests/RESTAPI/22_changeslogs/3_item/18_update_item_property_number.js
+++ b/tests/RESTAPI/22_changeslogs/3_item/18_update_item_property_number.js
@@ -1,0 +1,72 @@
+const supertest = require('supertest');
+const assert = require('assert');
+const is = require('is_js');
+
+const request = supertest('http://127.0.0.1/fusionsuite/backend');
+const requestDB = supertest('http://127.0.0.1:8012');
+
+describe('changes | items | update number type property', function () {
+  it('Update number property of the item', function (done) {
+    request
+      .patch('/v1/items/' + global.itemId + '/property/' + global.properties.number)
+      .send(
+        {
+          value: 666,
+        })
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('get the item and check if changes has new entry', function (done) {
+    global.changesEntries += 1;
+    request
+      .get('/v1/items/' + global.itemId)
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.not.empty(response.body));
+        assert(is.equal('laptop yyy6yy', response.body.name));
+        assert(is.propertyDefined(response.body, 'changes'));
+        assert(is.equal(global.changesEntries, response.body.changes.length), 'must have ' + global.changesEntries + ' changes');
+
+        const lastChanges = response.body.changes[(global.changesEntries - 1)];
+        assert(is.equal('admin', lastChanges.username), 'must have username = admin');
+        assert(is.equal('42', lastChanges.old_value), 'old value is wrong');
+        assert(is.equal('666', lastChanges.new_value), 'new value is wrong');
+        assert(is.equal('admin changed property with type number to "666"', lastChanges.message), 'wrong message');
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('check changes rows in database table when update property - must have only 1 rows more', function (done) {
+    requestDB
+      .get('/count/changes/' + global.changesCnt)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        global.changesCnt += 1;
+        assert(is.equal(global.changesCnt, response.body.count), 'have ' + response.body.count + ' instead ' + global.changesCnt);
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.body);
+        }
+        return done();
+      });
+  });
+});

--- a/tests/RESTAPI/22_changeslogs/3_item/19_update_item_property_propertylink.js
+++ b/tests/RESTAPI/22_changeslogs/3_item/19_update_item_property_propertylink.js
@@ -1,0 +1,72 @@
+const supertest = require('supertest');
+const assert = require('assert');
+const is = require('is_js');
+
+const request = supertest('http://127.0.0.1/fusionsuite/backend');
+const requestDB = supertest('http://127.0.0.1:8012');
+
+describe('changes | items | update propertylink type property', function () {
+  it('Update propertylink property of the item', function (done) {
+    request
+      .patch('/v1/items/' + global.itemId + '/property/' + global.properties.propertylink)
+      .send(
+        {
+          value: 2,
+        })
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('get the item and check if changes has new entry', function (done) {
+    global.changesEntries += 1;
+    request
+      .get('/v1/items/' + global.itemId)
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.not.empty(response.body));
+        assert(is.equal('laptop yyy6yy', response.body.name));
+        assert(is.propertyDefined(response.body, 'changes'));
+        assert(is.equal(global.changesEntries, response.body.changes.length), 'must have ' + global.changesEntries + ' changes');
+
+        const lastChanges = response.body.changes[(global.changesEntries - 1)];
+        assert(is.equal('admin', lastChanges.username), 'must have username = admin');
+        assert(is.equal('{"id":1,"name":"First name"}', lastChanges.old_value), 'old value is wrong');
+        assert(is.equal('{"id":2,"name":"Last name"}', lastChanges.new_value), 'new value is wrong');
+        assert(is.equal('admin changed "property with type propertylink" to "Last name"', lastChanges.message), 'wrong message');
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('check changes rows in database table when update property - must have only 1 rows more', function (done) {
+    requestDB
+      .get('/count/changes/' + global.changesCnt)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        global.changesCnt += 1;
+        assert(is.equal(global.changesCnt, response.body.count), 'have ' + response.body.count + ' instead ' + global.changesCnt);
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.body);
+        }
+        return done();
+      });
+  });
+});

--- a/tests/RESTAPI/22_changeslogs/3_item/20_update_item_property_string.js
+++ b/tests/RESTAPI/22_changeslogs/3_item/20_update_item_property_string.js
@@ -1,0 +1,72 @@
+const supertest = require('supertest');
+const assert = require('assert');
+const is = require('is_js');
+
+const request = supertest('http://127.0.0.1/fusionsuite/backend');
+const requestDB = supertest('http://127.0.0.1:8012');
+
+describe('changes | items | update string type property', function () {
+  it('Update string property of the item', function (done) {
+    request
+      .patch('/v1/items/' + global.itemId + '/property/' + global.properties.string)
+      .send(
+        {
+          value: 'very new!',
+        })
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('get the item and check if changes has new entry', function (done) {
+    global.changesEntries += 1;
+    request
+      .get('/v1/items/' + global.itemId)
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.not.empty(response.body));
+        assert(is.equal('laptop yyy6yy', response.body.name));
+        assert(is.propertyDefined(response.body, 'changes'));
+        assert(is.equal(global.changesEntries, response.body.changes.length), 'must have ' + global.changesEntries + ' changes');
+
+        const lastChanges = response.body.changes[(global.changesEntries - 1)];
+        assert(is.equal('admin', lastChanges.username), 'must have username = admin');
+        assert(is.equal('my default value', lastChanges.old_value), 'old value is wrong');
+        assert(is.equal('very new!', lastChanges.new_value), 'new value is wrong');
+        assert(is.equal('admin changed property with type string to "very new!"', lastChanges.message), 'wrong message');
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('check changes rows in database table when update property - must have only 1 rows more', function (done) {
+    requestDB
+      .get('/count/changes/' + global.changesCnt)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        global.changesCnt += 1;
+        assert(is.equal(global.changesCnt, response.body.count), 'have ' + response.body.count + ' instead ' + global.changesCnt);
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.body);
+        }
+        return done();
+      });
+  });
+});

--- a/tests/RESTAPI/22_changeslogs/3_item/21_update_item_property_text.js
+++ b/tests/RESTAPI/22_changeslogs/3_item/21_update_item_property_text.js
@@ -1,0 +1,72 @@
+const supertest = require('supertest');
+const assert = require('assert');
+const is = require('is_js');
+
+const request = supertest('http://127.0.0.1/fusionsuite/backend');
+const requestDB = supertest('http://127.0.0.1:8012');
+
+describe('changes | items | update text type property', function () {
+  it('Update text property of the item', function (done) {
+    request
+      .patch('/v1/items/' + global.itemId + '/property/' + global.properties.text)
+      .send(
+        {
+          value: 'Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry\'s standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.',
+        })
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('get the item and check if changes has new entry', function (done) {
+    global.changesEntries += 1;
+    request
+      .get('/v1/items/' + global.itemId)
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.not.empty(response.body));
+        assert(is.equal('laptop yyy6yy', response.body.name));
+        assert(is.propertyDefined(response.body, 'changes'));
+        assert(is.equal(global.changesEntries, response.body.changes.length), 'must have ' + global.changesEntries + ' changes');
+
+        const lastChanges = response.body.changes[(global.changesEntries - 1)];
+        assert(is.equal('admin', lastChanges.username), 'must have username = admin');
+        assert(is.equal('my default value\nMultiple lines', lastChanges.old_value), 'old value is wrong');
+        assert(is.equal('Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry\'s standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.', lastChanges.new_value), 'new value is wrong');
+        assert(is.equal('admin changed property with type text to "Lorem Ipsum is simply dummy text of the printing a..."', lastChanges.message), 'wrong message');
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('check changes rows in database table when update property - must have only 1 rows more', function (done) {
+    requestDB
+      .get('/count/changes/' + global.changesCnt)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        global.changesCnt += 1;
+        assert(is.equal(global.changesCnt, response.body.count), 'have ' + response.body.count + ' instead ' + global.changesCnt);
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.body);
+        }
+        return done();
+      });
+  });
+});

--- a/tests/RESTAPI/22_changeslogs/3_item/22_update_item_property_time.js
+++ b/tests/RESTAPI/22_changeslogs/3_item/22_update_item_property_time.js
@@ -1,0 +1,72 @@
+const supertest = require('supertest');
+const assert = require('assert');
+const is = require('is_js');
+
+const request = supertest('http://127.0.0.1/fusionsuite/backend');
+const requestDB = supertest('http://127.0.0.1:8012');
+
+describe('changes | items | update time type property', function () {
+  it('Update time property of the item', function (done) {
+    request
+      .patch('/v1/items/' + global.itemId + '/property/' + global.properties.time)
+      .send(
+        {
+          value: '14:59:52',
+        })
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('get the item and check if changes has new entry', function (done) {
+    global.changesEntries += 1;
+    request
+      .get('/v1/items/' + global.itemId)
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.not.empty(response.body));
+        assert(is.equal('laptop yyy6yy', response.body.name));
+        assert(is.propertyDefined(response.body, 'changes'));
+        assert(is.equal(global.changesEntries, response.body.changes.length), 'must have ' + global.changesEntries + ' changes');
+
+        const lastChanges = response.body.changes[(global.changesEntries - 1)];
+        assert(is.equal('admin', lastChanges.username), 'must have username = admin');
+        assert(is.equal('07:14:58', lastChanges.old_value), 'old value is wrong');
+        assert(is.equal('14:59:52', lastChanges.new_value), 'new value is wrong');
+        assert(is.equal('admin changed property with type time to "14:59:52"', lastChanges.message), 'wrong message');
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('check changes rows in database table when update property - must have only 1 rows more', function (done) {
+    requestDB
+      .get('/count/changes/' + global.changesCnt)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        global.changesCnt += 1;
+        assert(is.equal(global.changesCnt, response.body.count), 'have ' + response.body.count + ' instead ' + global.changesCnt);
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.body);
+        }
+        return done();
+      });
+  });
+});

--- a/tests/RESTAPI/22_changeslogs/3_item/23_update_item_property_typelink.js
+++ b/tests/RESTAPI/22_changeslogs/3_item/23_update_item_property_typelink.js
@@ -1,0 +1,72 @@
+const supertest = require('supertest');
+const assert = require('assert');
+const is = require('is_js');
+
+const request = supertest('http://127.0.0.1/fusionsuite/backend');
+const requestDB = supertest('http://127.0.0.1:8012');
+
+describe('changes | items | update typelink type property', function () {
+  it('Update typelink property of the item', function (done) {
+    request
+      .patch('/v1/items/' + global.itemId + '/property/' + global.properties.typelink)
+      .send(
+        {
+          value: 2,
+        })
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('get the item and check if changes has new entry', function (done) {
+    global.changesEntries += 1;
+    request
+      .get('/v1/items/' + global.itemId)
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.not.empty(response.body));
+        assert(is.equal('laptop yyy6yy', response.body.name));
+        assert(is.propertyDefined(response.body, 'changes'));
+        assert(is.equal(global.changesEntries, response.body.changes.length), 'must have ' + global.changesEntries + ' changes');
+
+        const lastChanges = response.body.changes[(global.changesEntries - 1)];
+        assert(is.equal('admin', lastChanges.username), 'must have username = admin');
+        assert(is.equal('{"id":1,"name":"Organization"}', lastChanges.old_value), 'old value is wrong');
+        assert(is.equal('{"id":2,"name":"Users"}', lastChanges.new_value), 'new value is wrong');
+        assert(is.equal('admin changed "property with type typelink" to "Users"', lastChanges.message), 'wrong message');
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('check changes rows in database table when update property - must have only 1 rows more', function (done) {
+    requestDB
+      .get('/count/changes/' + global.changesCnt)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        global.changesCnt += 1;
+        assert(is.equal(global.changesCnt, response.body.count), 'have ' + response.body.count + ' instead ' + global.changesCnt);
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.body);
+        }
+        return done();
+      });
+  });
+});

--- a/tests/RESTAPI/22_changeslogs/3_item/24_update_item_property_typelinks.js
+++ b/tests/RESTAPI/22_changeslogs/3_item/24_update_item_property_typelinks.js
@@ -1,0 +1,330 @@
+const supertest = require('supertest');
+const assert = require('assert');
+const is = require('is_js');
+
+const request = supertest('http://127.0.0.1/fusionsuite/backend');
+const requestDB = supertest('http://127.0.0.1:8012');
+
+describe('changes | items | update typelinks type property', function () {
+  it('add an itemlink property of the item', function (done) {
+    request
+      .post('/v1/items/' + global.itemId + '/property/' + global.properties.typelinks + '/typelinks')
+      .send(
+        {
+          value: 2,
+        })
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('get the items (after added) and check if changes has new entry', function (done) {
+    global.changesEntries += 1;
+    request
+      .get('/v1/items/' + global.itemId)
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.not.empty(response.body));
+        assert(is.equal('laptop yyy6yy', response.body.name));
+        assert(is.propertyDefined(response.body, 'changes'));
+        assert(is.equal(global.changesEntries, response.body.changes.length), 'must have ' + global.changesEntries + ' changes');
+
+        const lastChanges = response.body.changes[(global.changesEntries - 1)];
+        assert(is.equal('admin', lastChanges.username), 'must have username = admin');
+        assert(is.null(lastChanges.old_value), 'old value is wrong');
+        assert(is.equal('{"id":2,"name":"Users"}', lastChanges.new_value), 'new value is wrong');
+        assert(is.equal('admin added "Users" to "property with type typelinks"', lastChanges.message), 'wrong message');
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('check changes rows in database table when add property - must have only 1 rows more', function (done) {
+    requestDB
+      .get('/count/changes/' + global.changesCnt)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        global.changesCnt += 1;
+        assert(is.equal(global.changesCnt, response.body.count), 'have ' + response.body.count + ' instead ' + global.changesCnt);
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.body);
+        }
+        return done();
+      });
+  });
+
+  it('delete a typelink property of the item', function (done) {
+    request
+      .delete('/v1/items/' + global.itemId + '/property/' + global.properties.typelinks + '/typelinks/1')
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('get the items (after deleted) and check if changes has new entry', function (done) {
+    global.changesEntries += 1;
+    request
+      .get('/v1/items/' + global.itemId)
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.not.empty(response.body));
+        assert(is.equal('laptop yyy6yy', response.body.name));
+        assert(is.propertyDefined(response.body, 'changes'));
+        assert(is.equal(global.changesEntries, response.body.changes.length), 'must have ' + global.changesEntries + ' changes');
+
+        const lastChanges = response.body.changes[(global.changesEntries - 1)];
+        assert(is.equal('admin', lastChanges.username), 'must have username = admin');
+        assert(is.equal('{"id":1,"name":"Organization"}', lastChanges.old_value), 'old value is wrong');
+        assert(is.null(lastChanges.new_value), 'new value is wrong');
+        assert(is.equal('admin deleted property "property with type typelinks" named "Organization"', lastChanges.message), 'wrong message');
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('check changes rows in database table when delete property - must have only 1 rows more', function (done) {
+    requestDB
+      .get('/count/changes/' + global.changesCnt)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        global.changesCnt += 1;
+        assert(is.equal(global.changesCnt, response.body.count), 'have ' + response.body.count + ' instead ' + global.changesCnt);
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.body);
+        }
+        return done();
+      });
+  });
+
+  it('Update typelinks property of the item to [1, 2]', function (done) {
+    request
+      .patch('/v1/items/' + global.itemId + '/property/' + global.properties.typelinks)
+      .send(
+        {
+          value: [1, 2],
+        })
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('get the item and check if changes has new entry', function (done) {
+    global.changesEntries += 1;
+    request
+      .get('/v1/items/' + global.itemId)
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.not.empty(response.body));
+        assert(is.equal('laptop yyy6yy', response.body.name));
+        assert(is.propertyDefined(response.body, 'changes'));
+        assert(is.equal(global.changesEntries, response.body.changes.length), 'must have ' + global.changesEntries + ' changes');
+
+        const lastChanges = response.body.changes[(global.changesEntries - 1)];
+        assert(is.equal('admin', lastChanges.username), 'must have username = admin');
+        assert(is.null(lastChanges.old_value), 'old value is wrong');
+        assert(is.equal('{"id":1,"name":"Organization"}', lastChanges.new_value), 'new value is wrong');
+        assert(is.equal('admin added "Organization" to "property with type typelinks"', lastChanges.message), 'wrong message');
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('check changes rows in database table when update to [1, 2] - must have only 1 rows more', function (done) {
+    requestDB
+      .get('/count/changes/' + global.changesCnt)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        global.changesCnt += 1;
+        assert(is.equal(global.changesCnt, response.body.count), 'have ' + response.body.count + ' instead ' + global.changesCnt);
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.body);
+        }
+        return done();
+      });
+  });
+
+  it('Update typelinks property of the item to [2] (will delete the id 1', function (done) {
+    request
+      .patch('/v1/items/' + global.itemId + '/property/' + global.properties.typelinks)
+      .send(
+        {
+          value: [2],
+        })
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('get the item and check if changes has new entry after reduced items', function (done) {
+    global.changesEntries += 1;
+    request
+      .get('/v1/items/' + global.itemId)
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.not.empty(response.body));
+        assert(is.equal('laptop yyy6yy', response.body.name));
+        assert(is.propertyDefined(response.body, 'changes'));
+        assert(is.equal(global.changesEntries, response.body.changes.length), 'must have ' + global.changesEntries + ' changes');
+
+        const lastChanges = response.body.changes[(global.changesEntries - 1)];
+        assert(is.equal('admin', lastChanges.username), 'must have username = admin');
+        assert(is.equal('{"id":1,"name":"Organization"}', lastChanges.old_value), 'old value is wrong');
+        assert(is.null(lastChanges.new_value), 'new value is wrong');
+        assert(is.equal('admin deleted property "property with type typelinks" named "Organization"', lastChanges.message), 'wrong message');
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('check changes rows in database table when update to [2] - must have only 1 rows more', function (done) {
+    requestDB
+      .get('/count/changes/' + global.changesCnt)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        global.changesCnt += 1;
+        assert(is.equal(global.changesCnt, response.body.count), 'have ' + response.body.count + ' instead ' + global.changesCnt);
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.body);
+        }
+        return done();
+      });
+  });
+
+  it('Update typelinks property of the item to null', function (done) {
+    request
+      .patch('/v1/items/' + global.itemId + '/property/' + global.properties.typelinks)
+      .send(
+        {
+          value: null,
+        })
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('get the item and check if changes has 2 new entries after null', function (done) {
+    global.changesEntries += 2;
+    request
+      .get('/v1/items/' + global.itemId)
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        assert(is.not.empty(response.body));
+        assert(is.equal('laptop yyy6yy', response.body.name));
+        assert(is.propertyDefined(response.body, 'changes'));
+        assert(is.equal(global.changesEntries, response.body.changes.length), 'must have ' + global.changesEntries + ' changes');
+
+        let lastChanges = response.body.changes[(global.changesEntries - 2)];
+        assert(is.equal('admin', lastChanges.username), '(first) must have username = admin');
+        assert(is.equal('{"id":2,"name":"Users"}', lastChanges.old_value), '(first) old value is wrong');
+        assert(is.null(lastChanges.new_value), '(first) new value is wrong');
+        assert(is.equal('admin deleted property "property with type typelinks" named "Users"', lastChanges.message), '(first) wrong message');
+
+        lastChanges = response.body.changes[(global.changesEntries - 1)];
+        assert(is.equal('admin', lastChanges.username), '(second) must have username = admin');
+        assert(is.null(lastChanges.old_value), '(second) old value is wrong');
+        assert(is.null(lastChanges.new_value), '(second) new value is wrong');
+        assert(is.equal('admin added null to "property with type typelinks"', lastChanges.message), '(second) wrong message');
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('check changes rows in database table when update to null - must have only 2 rows more', function (done) {
+    requestDB
+      .get('/count/changes/' + global.changesCnt)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(function (response) {
+        global.changesCnt += 2;
+        assert(is.equal(global.changesCnt, response.body.count), 'have ' + response.body.count + ' instead ' + global.changesCnt);
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.body);
+        }
+        return done();
+      });
+  });
+});

--- a/tests/RESTAPI/22_changeslogs/3_item/51_delete_item.js
+++ b/tests/RESTAPI/22_changeslogs/3_item/51_delete_item.js
@@ -1,0 +1,85 @@
+const supertest = require('supertest');
+const assert = require('assert');
+const is = require('is_js');
+
+const request = supertest('http://127.0.0.1/fusionsuite/backend');
+const requestDB = supertest('http://127.0.0.1:8012');
+
+describe('changes | items | delete the item', function () {
+  it('soft delete an item', function (done) {
+    request
+      .delete('/v1/items/' + global.itemId)
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('check changes rows in database table when soft delete - must have only 1 rows more', function (done) {
+    requestDB
+      .get('/count/changes/' + global.changesCnt)
+      .expect(200)
+      .expect(function (response) {
+        global.changesCnt += 1;
+        assert(is.equal(global.changesCnt, response.body.count), 'have ' + response.body.count + ' instead ' + global.changesCnt);
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.body);
+        }
+        return done();
+      });
+  });
+
+  it('hard delete an item', function (done) {
+    request
+      .delete('/v1/items/' + global.itemId)
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('check changes rows in database table when hard delete - must have only 1 rows more', function (done) {
+    requestDB
+      .get('/count/changes/' + global.changesCnt)
+      .expect(200)
+      .expect(function (response) {
+        global.changesCnt += 1;
+        assert(is.equal(global.changesCnt, response.body.count), 'have ' + response.body.count + ' instead ' + global.changesCnt);
+
+        // test deleted changes row
+        assert(is.equal(1, response.body.rows.length), 'wrong number of changes');
+        assert(is.equal('admin deleted this item', response.body.rows[0].message), 'wrong message');
+        // replace dates to be easier to compare
+        response.body.rows[0].old_value = response.body.rows[0].old_value.replace(/("20\d{2}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})/g, '"**date**');
+        response.body.rows[0].old_value = response.body.rows[0].old_value.replace(/("20\d{2}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.000000Z)/g, '"**date**');
+        assert(
+          is.equal(
+            '{"id":' + global.itemId + ',"name":"laptop yyy6yy","id_bytype":1,"sub_organization":false,"parent_id":null,"treepath":null,"created_at":"**date**","updated_at":"**date**","deleted_at":"**date**","created_by":{"id":2,"name":"admin","first_name":"Steve","last_name":"Rogers"},"updated_by":{"id":2,"name":"admin","first_name":"Steve","last_name":"Rogers"},"deleted_by":{"id":2,"name":"admin","first_name":"Steve","last_name":"Rogers"},"properties":[],"organization":{"id":1,"name":"My organization"}}',
+            response.body.rows[0].old_value,
+          ),
+          'old value is wrong ' + response.body.rows[0].old_value,
+        );
+        assert(is.equal('hard delete', response.body.rows[0].new_value), 'new value is wrong');
+      })
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.body);
+        }
+        return done();
+      });
+  });
+});

--- a/tests/RESTAPI/22_changeslogs/3_item/52_delete_type_properties.js
+++ b/tests/RESTAPI/22_changeslogs/3_item/52_delete_type_properties.js
@@ -1,0 +1,69 @@
+const supertest = require('supertest');
+
+const request = supertest('http://127.0.0.1/fusionsuite/backend');
+
+describe('changes | items | delete the type and properties', function () {
+  it('soft delete a type', function (done) {
+    request
+      .delete('/v1/config/types/' + global.typeId)
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  it('hard delete a type', function (done) {
+    request
+      .delete('/v1/config/types/' + global.typeId)
+      .set('Accept', 'application/json')
+      .set('Authorization', 'Bearer ' + global.token)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .end(function (err, response) {
+        if (err) {
+          return done(err + ' | Response: ' + response.text);
+        }
+        return done();
+      });
+  });
+
+  // delete all properties
+  // eslint-disable-next-line mocha/no-setup-in-describe
+  for (const propertyType in global.properties) {
+    it('soft delete the property ' + propertyType, function (done) {
+      request
+        .delete('/v1/config/properties/' + global.properties[propertyType])
+        .set('Accept', 'application/json')
+        .set('Authorization', 'Bearer ' + global.token)
+        .expect(200)
+        .expect('Content-Type', /json/)
+        .end(function (err, response) {
+          if (err) {
+            return done(err + ' | Response: ' + response.text);
+          }
+          return done();
+        });
+    });
+
+    it('hard delete the property ' + propertyType, function (done) {
+      request
+        .delete('/v1/config/properties/' + global.properties[propertyType])
+        .set('Accept', 'application/json')
+        .set('Authorization', 'Bearer ' + global.token)
+        .expect(200)
+        .expect('Content-Type', /json/)
+        .end(function (err, response) {
+          if (err) {
+            return done(err + ' | Response: ' + response.text);
+          }
+          return done();
+        });
+    });
+  }
+});

--- a/tests/RESTAPI/testDatabaseAccess.php
+++ b/tests/RESTAPI/testDatabaseAccess.php
@@ -14,9 +14,41 @@ $capsule->setEventDispatcher(new Dispatcher(new Container()));
 $capsule->setAsGlobal();
 $capsule->bootEloquent();
 
+define('STDOUT', fopen('php://stdout', 'w'));
+fwrite(STDOUT, 'URI: '.print_r($_SERVER['REQUEST_URI'], true));
+fwrite(STDOUT, "\n");
+
 preg_match('/\/truncate\/(\w+)/', $_SERVER['REQUEST_URI'], $matches, PREG_OFFSET_CAPTURE);
 
 if (count($matches) == 2)
 {
   $capsule->table($matches[1][0])->truncate();
+}
+
+preg_match('/\/count\/(\w+)\/(\d+)/', $_SERVER['REQUEST_URI'], $matches, PREG_OFFSET_CAPTURE);
+if (count($matches) == 3)
+{
+  header('Content-Type: application/json; charset=utf-8');
+  $data = [
+    'count' => 0,
+    'rows'  => []
+  ];
+
+  $data['count'] = $capsule->table($matches[1][0])->count();
+
+  $data['rows'] = $capsule->table($matches[1][0])->orderBy('id')->skip($matches[2][0])->take(200)->get()->toArray();
+  echo json_encode($data);
+  exit;
+}
+
+preg_match('/\/count\/(\w+)/', $_SERVER['REQUEST_URI'], $matches, PREG_OFFSET_CAPTURE);
+if (count($matches) == 2)
+{
+  header('Content-Type: application/json; charset=utf-8');
+  $data = [
+    'count' => 0,
+    'rows'  => []
+  ];
+  $data['count'] = $capsule->table($matches[1][0])->count();
+  echo json_encode($data);
 }


### PR DESCRIPTION
Changes proposed in this pull request:

- add changelogs with message, old value, new value...

How to test the feature manually:

1. update a property, type item and you will have property changeslgos in the JSON (only get one, not when get all)



Pull request checklist:

- [x] code is manually tested
- [x] tests are updated
- [x] commit messages are relevant
- [x] documentation is updated (including code comments, commit messages…)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and precise `N/A` next to it._

Related to #
