### PR TITLE
Fix with github action and ubuntu 22.04

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -211,6 +211,11 @@ jobs:
     - name: install the action scripts
       run: ./bin/cli install
 
+    - name: copy PHP files to /var/www
+      run: |
+        sudo rm -fr /var/www/*
+        sudo cp -fr ./ /var/www/
+
     - name: Set up Node.js
       uses: actions/setup-node@v2
       with:
@@ -314,6 +319,11 @@ jobs:
     - name: install the action scripts
       run: ./bin/cli install
 
+    - name: copy PHP files to /var/www
+      run: |
+        sudo rm -fr /var/www/*
+        sudo cp -fr ./ /var/www/
+
     - name: Set up Node.js
       uses: actions/setup-node@v2
       with:
@@ -415,6 +425,11 @@ jobs:
 
     - name: install the action scripts
       run: ./bin/cli install
+
+    - name: copy PHP files to /var/www
+      run: |
+        sudo rm -fr /var/www/*
+        sudo cp -fr ./ /var/www/
 
     - name: Set up Node.js
       uses: actions/setup-node@v2
@@ -523,6 +538,11 @@ jobs:
 
   #   - name: install the action scripts
   #     run: ./bin/cli install
+
+  #  - name: copy PHP files to /var/www
+  #    run: |
+  #      sudo rm -fr /var/www/*
+  #      sudo cp -fr ./ /var/www/
 
   #   - name: Set up Node.js
   #     uses: actions/setup-node@v2

--- a/tests/RESTAPI/fusionsuite.conf
+++ b/tests/RESTAPI/fusionsuite.conf
@@ -2,7 +2,7 @@ server {
   listen 80 default_server;
   listen [::]:80 default_server;
 
-  root /home/runner/work/backend/backend/public;
+  root /var/www/public;
   index index.php index.html;
   server_name _;
   add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;


### PR DESCRIPTION
Changes proposed in this pull request:

- /home is now protected for php-fpm, unable to unprotect it, so only solution is to copy code to /var/ww/ and use this forlder in nginx configuration
-
-

How to test the feature manually:

1. only on github
2.
3.

Pull request checklist:

- [ ] code is manually tested
- [ ] tests are updated
- [x] commit messages are relevant
- [ ] documentation is updated (including code comments, commit messages…)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and precise `N/A` next to it._

Related to #
