### PR TITLE
Update css for documentation to be easier to read / parse

### DIFF
--- a/devtools/template/src/css/main.css
+++ b/devtools/template/src/css/main.css
@@ -346,7 +346,7 @@ pre code.sample-request-response-json {
 .sidenav > li > a {
   display: block;
   margin: 0;
-  padding: 6px 28px;
+  padding: 6px 10px;
   border: 0;
   border-left: transparent 4px solid;
   border-right: transparent 4px solid;
@@ -356,7 +356,7 @@ pre code.sample-request-response-json {
 }
 
 .sidenav > li.nav-header > a {
-  padding: 5px 15px 5px 20px;
+  padding: 5px 15px 5px 10px;
   font-family: "Roboto", monospace, sans-serif;
   font-weight: 700;
   font-size: 15px;


### PR DESCRIPTION
Changes proposed in this pull request:

- Modification of padding left of documentation menu

How to test the feature manually:

1. see the documentation of REST API

Pull request checklist:

- [x] code is manually tested
- [ ] tests are updated
- [x] commit messages are relevant
- [x] documentation is updated (including code comments, commit messages…)

