### PR TITLE
ENhance error messages with trace and catch php error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
         "illuminate/events": "9.*",
         "rakit/validation": "^1.4",
         "adhocore/cli": "^0.9.0",
-        "genealabs/laravel-pivot-events": "9.*"
+        "genealabs/laravel-pivot-events": "9.*",
+        "symfony/error-handler": "^6.3"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9cd1ce4f517d62dd0e1a831280fe0c3b",
+    "content-hash": "54bab59d2547fde30945278dd80a800b",
     "packages": [
         {
             "name": "adhocore/cli",
@@ -3334,6 +3334,80 @@
             "time": "2023-03-01T10:25:55+00:00"
         },
         {
+            "name": "symfony/error-handler",
+            "version": "v6.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/error-handler.git",
+                "reference": "99d2d814a6351461af350ead4d963bd67451236f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/error-handler/zipball/99d2d814a6351461af350ead4d963bd67451236f",
+                "reference": "99d2d814a6351461af350ead4d963bd67451236f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/log": "^1|^2|^3",
+                "symfony/var-dumper": "^5.4|^6.0"
+            },
+            "conflict": {
+                "symfony/deprecation-contracts": "<2.5"
+            },
+            "require-dev": {
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/http-kernel": "^5.4|^6.0",
+                "symfony/serializer": "^5.4|^6.0"
+            },
+            "bin": [
+                "Resources/bin/patch-type-declarations"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\ErrorHandler\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides tools to manage errors and ease debugging PHP code",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/error-handler/tree/v6.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-05-10T12:03:13+00:00"
+        },
+        {
             "name": "symfony/filesystem",
             "version": "v6.2.10",
             "source": {
@@ -4158,6 +4232,88 @@
                 }
             ],
             "time": "2023-03-01T10:32:47+00:00"
+        },
+        {
+            "name": "symfony/var-dumper",
+            "version": "v6.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/var-dumper.git",
+                "reference": "6acdcd5c122074ee9f7b051e4fb177025c277a0e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/6acdcd5c122074ee9f7b051e4fb177025c277a0e",
+                "reference": "6acdcd5c122074ee9f7b051e4fb177025c277a0e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "conflict": {
+                "symfony/console": "<5.4"
+            },
+            "require-dev": {
+                "ext-iconv": "*",
+                "symfony/console": "^5.4|^6.0",
+                "symfony/process": "^5.4|^6.0",
+                "symfony/uid": "^5.4|^6.0",
+                "twig/twig": "^2.13|^3.0.4"
+            },
+            "bin": [
+                "Resources/bin/var-dump-server"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "Resources/functions/dump.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\VarDumper\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides mechanisms for walking through any arbitrary PHP variable",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "debug",
+                "dump"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/var-dumper/tree/v6.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-05-25T13:09:35+00:00"
         },
         {
             "name": "tuupola/base62",

--- a/public/index.php
+++ b/public/index.php
@@ -24,7 +24,7 @@ use Slim\Factory\AppFactory;
 use Illuminate\Database\Capsule\Manager as Capsule;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Container\Container;
-use \Symfony\Component\ErrorHandler\ErrorHandler as SymfonyErrorHandler;
+use Symfony\Component\ErrorHandler\ErrorHandler as SymfonyErrorHandler;
 
 // use DateTime;
 

--- a/public/index.php
+++ b/public/index.php
@@ -24,6 +24,7 @@ use Slim\Factory\AppFactory;
 use Illuminate\Database\Capsule\Manager as Capsule;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Container\Container;
+use \Symfony\Component\ErrorHandler\ErrorHandler as SymfonyErrorHandler;
 
 // use DateTime;
 
@@ -163,6 +164,10 @@ $customErrorHandler = function (
       "status"  => "error",
       "message" => $exception->getMessage()
     ];
+    if ($exception->getCode() == 0 || $exception->getCode() >= 500)
+    {
+      $error['trace'] = $exception->getTraceAsString();
+    }
     $response = $app->getResponseFactory()->createResponse();
     $response->getBody()->write(json_encode($error));
     return $response->withStatus($exception->getCode())->withHeader('Content-Type', 'application/json');
@@ -172,6 +177,10 @@ $customErrorHandler = function (
     "status"  => "error",
     "message" => $exception->getMessage()
   ];
+  if ($exception->getCode() == 0 || $exception->getCode() >= 500)
+  {
+    $error['trace'] = $exception->getTraceAsString();
+  }
   $response = $app->getResponseFactory()->createResponse();
   $response->getBody()->write(json_encode($error));
   return $response->withStatus(500)->withHeader('Content-Type', 'application/json');
@@ -188,5 +197,8 @@ $app->get('/', function (Request $request, Response $response, $args)
 
 $errorMiddleware = $app->addErrorMiddleware(true, true, true);
 $errorMiddleware->setDefaultErrorHandler($customErrorHandler);
+
+// get php errors (warning...)
+SymfonyErrorHandler::register();
 
 $app->run();

--- a/src/v1/Controllers/Token.php
+++ b/src/v1/Controllers/Token.php
@@ -208,7 +208,7 @@ final class Token
       // we only want have the encryption and the data OK, no need to validate the time
       if ($exception->getMessage() != 'Expired token')
       {
-        throw $exception;
+        throw new \Exception($exception->getMessage(), 400);
       }
     }
     // decode the paylod

--- a/src/v1/Models/Item.php
+++ b/src/v1/Models/Item.php
@@ -209,6 +209,15 @@ class Item extends Model
   public function getOrganizationAttribute()
   {
     $org = \App\v1\Models\Item::find($this->attributes['organization_id']);
+    // special case when delete an organization on itself (do warning when hard delete)
+    if (is_null($org) && $this->attributes['id'] == $this->attributes['organization_id'])
+    {
+      return [
+        'id'   => 0,
+        'name' => ''
+      ];
+    }
+    // normal case
     return [
       'id'   => $org->id,
       'name' => $org->name

--- a/tests/RESTAPI/19_refreshToken/02_token-users.js
+++ b/tests/RESTAPI/19_refreshToken/02_token-users.js
@@ -133,7 +133,7 @@ describe('refresh token | usage of the refreshtoken', function () {
         refreshtoken: global.refreshTokenUser1,
       })
       .set('Accept', 'application/json')
-      .expect(500)
+      .expect(400)
       .expect('Content-Type', /json/)
       .expect(function (response) {
         assert(is.propertyCount(response.body, 2));
@@ -156,7 +156,7 @@ describe('refresh token | usage of the refreshtoken', function () {
         refreshtoken: global.refreshTokenUser1,
       })
       .set('Accept', 'application/json')
-      .expect(500)
+      .expect(400)
       .expect('Content-Type', /json/)
       .expect(function (response) {
         assert(is.propertyCount(response.body, 2));


### PR DESCRIPTION
Changes proposed in this pull request:

- catch php error message and add trace in this case
-
-

How to test the feature manually:

1.
2.
3.

Pull request checklist:

- [x] code is manually tested
- [x] tests are updated
- [x] commit messages are relevant
- [ ] documentation is updated (including code comments, commit messages…)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and precise `N/A` next to it._

Related to #
