### PR TITLE
Add uniqid generation for internal name

### DIFF
--- a/src/v1/Controllers/Config/Property.php
+++ b/src/v1/Controllers/Config/Property.php
@@ -1245,7 +1245,7 @@ final class Property
     {
       if (property_exists($data, 'internalname') === false)
       {
-        $properties['internalname'] = preg_replace("/[^a-z.]+/", "", strtolower($data->name));
+        $properties['internalname'] = uniqid(preg_replace("/[^a-z.0-9]+/", "", strtolower($data->name)));
       }
       else
       {
@@ -1310,7 +1310,7 @@ final class Property
   private function validateInternalnameAttribute($values = [])
   {
     $values[] = 'type:string';
-    $values[] = 'regex:/^[a-z.]+$/';
+    $values[] = 'regex:/^[a-z.0-9]+$/';
     $values[] = 'minchars:2';
     $values[] = 'maxchars:255';
     return implode('|', $values);

--- a/src/v1/Controllers/Config/Type.php
+++ b/src/v1/Controllers/Config/Type.php
@@ -756,7 +756,7 @@ final class Type
     // Validate the data format
     $dataFormat = [
       'name'                   => 'required|type:string',
-      'internalname'           => 'type:string|regex:/^[a-z.]+$/|minchars:2|maxchars:255',
+      'internalname'           => 'type:string|regex:/^[a-z.0-9]+$/|minchars:2|maxchars:255',
       'tree'                   => 'type:boolean|boolean',
       'allowtreemultipleroots' => 'type:boolean|boolean',
       'organization_id'        => 'type:integer|integer',
@@ -779,7 +779,7 @@ final class Type
     }
     if (property_exists($data, 'internalname') === false)
     {
-      $type->internalname = preg_replace("/[^a-z.]+/", "", strtolower($data->name));
+      $type->internalname = uniqid(preg_replace("/[^a-z.0-9]+/", "", strtolower($data->name)));
     }
     else
     {
@@ -833,7 +833,7 @@ final class Type
     {
       $dataFormat = [
         'name'         => 'required|type:string',
-        'internalname' => 'type:string|regex:/^[a-z.]+$/'
+        'internalname' => 'type:string|regex:/^[a-z.0-9]+$/'
       ];
       \App\v1\Common::validateData($type, $dataFormat);
 
@@ -854,7 +854,7 @@ final class Type
             {
               $dataFormat = [
                 'name'         => 'required|type:string',
-                'internalname' => 'type:string|regex:/^[a-z.]+$/',
+                'internalname' => 'type:string|regex:/^[a-z.0-9]+$/',
                 'valuetype'    => 'required|in:boolean,date,datetime,decimal,integer,itemlink,itemlinks,list,number,' .
                                   'propertylink,string,text,time,typelink,typelinks|type:string',
                 'regexformat'  => 'present|type:string',
@@ -907,7 +907,7 @@ final class Type
         {
           if (property_exists($property, 'internalname') === false)
           {
-            $property->internalname = preg_replace("/[^a-z.]+/", "", strtolower($property->name));
+            $property->internalname = uniqid(preg_replace("/[^a-z.0-9]+/", "", strtolower($property->name)));
           }
           $prop = \App\v1\Models\Config\Property::firstWhere('internalname', $property->internalname);
           if (is_null($prop))

--- a/tests/RESTAPI/08_roles/3_custom/structure/type/04_create_type.js
+++ b/tests/RESTAPI/08_roles/3_custom/structure/type/04_create_type.js
@@ -113,7 +113,9 @@ describe('roles | custom > structure > type | create type(s)', function () {
       .expect(200)
       .expect('Content-Type', /json/)
       .expect(function (response) {
-        assert(is.equal('mytype', response.body.internalname));
+        assert(is.startWith(response.body.internalname, 'mytype'));
+        const pattern = /^([a-z0-9.]+)$/;
+        assert(pattern.test(response.body.internalname), 'internalname not in right format');
       })
       .end(function (err, response) {
         if (err) {

--- a/tests/RESTAPI/08_roles/3_custom/structure/type/05_update_types.js
+++ b/tests/RESTAPI/08_roles/3_custom/structure/type/05_update_types.js
@@ -107,7 +107,9 @@ describe('roles | custom > structure > type | update type(s)', function () {
       .expect(200)
       .expect('Content-Type', /json/)
       .expect(function (response) {
-        assert(is.equal('mytype', response.body.internalname));
+        assert(is.startWith(response.body.internalname, 'mytype'));
+        const pattern = /^([a-z0-9.]+)$/;
+        assert(pattern.test(response.body.internalname), 'internalname not in right format');
         assert(is.equal('mytypeupdated2', response.body.name));
         assert(is.null(response.body.deleted_at));
       })

--- a/tests/RESTAPI/08_roles/3_custom/structure/type/06_softdelete_types.js
+++ b/tests/RESTAPI/08_roles/3_custom/structure/type/06_softdelete_types.js
@@ -101,7 +101,9 @@ describe('roles | custom > structure > type | soft delete type(s)', function () 
       .expect(200)
       .expect('Content-Type', /json/)
       .expect(function (response) {
-        assert(is.equal('mytype', response.body.internalname));
+        assert(is.startWith(response.body.internalname, 'mytype'));
+        const pattern = /^([a-z0-9.]+)$/;
+        assert(pattern.test(response.body.internalname), 'internalname not in right format');
         assert(is.equal('mytypeupdated2', response.body.name));
         assert(is.not.null(response.body.deleted_at));
       })

--- a/tests/RESTAPI/08_roles/3_custom/structure_custom/type/04_get_types.js
+++ b/tests/RESTAPI/08_roles/3_custom/structure_custom/type/04_get_types.js
@@ -88,7 +88,9 @@ describe('roles | custom > structure > custom > type | get type(s)', function ()
       .expect(200)
       .expect('Content-Type', /json/)
       .expect(function (response) {
-        assert(is.equal('mytype', response.body.internalname));
+        assert(is.startWith(response.body.internalname, 'mytype'));
+        const pattern = /^([a-z0-9.]+)$/;
+        assert(pattern.test(response.body.internalname), 'internalname not in right format');
       })
       .end(function (err, response) {
         if (err) {

--- a/tests/RESTAPI/08_roles/3_custom/structure_custom/type/05_update_types.js
+++ b/tests/RESTAPI/08_roles/3_custom/structure_custom/type/05_update_types.js
@@ -148,7 +148,9 @@ describe('roles | custom > structure > custom > type | update type(s)', function
       .expect(200)
       .expect('Content-Type', /json/)
       .expect(function (response) {
-        assert(is.equal('mytype', response.body.internalname));
+        assert(is.startWith(response.body.internalname, 'mytype'));
+        const pattern = /^([a-z0-9.]+)$/;
+        assert(pattern.test(response.body.internalname), 'internalname not in right format');
         assert(is.equal('mytypeupdated2', response.body.name));
         assert(is.null(response.body.deleted_at));
       })

--- a/tests/RESTAPI/08_roles/3_custom/structure_custom/type/06_softdelete_types.js
+++ b/tests/RESTAPI/08_roles/3_custom/structure_custom/type/06_softdelete_types.js
@@ -107,7 +107,9 @@ describe('roles | custom > structure > custom > type | soft delete type(s)', fun
       .expect(200)
       .expect('Content-Type', /json/)
       .expect(function (response) {
-        assert(is.equal('mytype', response.body.internalname));
+        assert(is.startWith(response.body.internalname, 'mytype'));
+        const pattern = /^([a-z0-9.]+)$/;
+        assert(pattern.test(response.body.internalname), 'internalname not in right format');
         assert(is.equal('mytypeupdated2', response.body.name));
         assert(is.not.null(response.body.deleted_at));
       })

--- a/tests/RESTAPI/21_itemPropertyWhenAddDeletePropertyToType/1_createType.js
+++ b/tests/RESTAPI/21_itemPropertyWhenAddDeletePropertyToType/1_createType.js
@@ -11,6 +11,7 @@ describe('itemPropertyWhenAddPropertyToType | create type', function () {
       .post('/v1/config/types')
       .send({
         name: 'testType',
+        internalname: 'testtype',
       })
       .set('Accept', 'application/json')
       .set('Authorization', 'Bearer ' + global.token)

--- a/tests/RESTAPI/22_changeslogs/2_type/9_delete_type.js
+++ b/tests/RESTAPI/22_changeslogs/2_type/9_delete_type.js
@@ -78,6 +78,7 @@ describe('changes | types | delete the type', function () {
         // replace dates to be easier to compare
         row.old_value = row.old_value.replace(/("20\d{2}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})/g, '"**date**');
         row.old_value = row.old_value.replace(/("20\d{2}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.000000Z)/g, '"**date**');
+        row.old_value = row.old_value.replace(/typeforchanges([a-z0-9.]+)"/, 'typeforchanges"');
         assert(
           is.equal(
             '{"id":' + global.typeId + ',"name":"test for a new name of the type","internalname":"typeforchanges","sub_organization":false,"modeling":"logical","tree":false,"allowtreemultipleroots":false,"unique_name":false,"created_at":"**date**","updated_at":"**date**","deleted_at":"**date**","created_by":{"id":2,"name":"admin","first_name":"Steve","last_name":"Rogers"},"updated_by":{"id":2,"name":"admin","first_name":"Steve","last_name":"Rogers"},"deleted_by":{"id":2,"name":"admin","first_name":"Steve","last_name":"Rogers"},"properties":[{"id":1,"name":"First name","internalname":"userfirstname","valuetype":"string","regexformat":null,"unit":null,"description":null,"canbenull":true,"setcurrentdate":null,"listvalues":[],"default":"","allowedtypes":[]},{"id":2,"name":"Last name","internalname":"userlastname","valuetype":"string","regexformat":null,"unit":null,"description":null,"canbenull":true,"setcurrentdate":null,"listvalues":[],"default":"","allowedtypes":[]}],"organization":{"id":1,"name":"My organization"}}',


### PR DESCRIPTION
Changes proposed in this pull request:

- generate internal name with the name cleaned + uniqid to prevent have 2 same internalname and have error if for example have a property named near and difference is specal chars)
-
-

How to test the feature manually:

1.
2.
3.

Pull request checklist:

- [x] code is manually tested
- [x] tests are updated
- [x] commit messages are relevant
- [x] documentation is updated (including code comments, commit messages…)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and precise `N/A` next to it._

Related to #
